### PR TITLE
feat: add get-technical-analysis MCP tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,12 @@ import {
   handleGetMarketAnalysis,
   handleGetHistoricalAnalysis,
   handleGetTopAssets,
+  handleGetTechnicalAnalysis,
   GetPriceArgumentsSchema,
   GetMarketAnalysisSchema,
   GetHistoricalAnalysisSchema,
   GetTopAssetsSchema,
+  GetTechnicalAnalysisSchema,
 } from './tools/index.js';
 
 export const configSchema = z.object({
@@ -133,6 +135,26 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetTopAssets(args);
+      return result as any;
+    }
+  );
+
+  server.registerTool(
+    "get-technical-analysis",
+    {
+      title: "Get Technical Analysis",
+      description: "Get the latest technical indicators for a cryptocurrency including SMA, EMA, RSI, MACD, and VWAP to assess momentum, trend direction, and overbought/oversold conditions.",
+      inputSchema: GetTechnicalAnalysisSchema.shape,
+      annotations: {
+        title: "Get Technical Analysis",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetTechnicalAnalysis(args);
       return result as any;
     }
   );

--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -1,6 +1,6 @@
 import { COINCAP_API_BASE, getCacheTtl } from '../config/index.js';
-import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse } from '../types/index.js';
-import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema } from './schemas.js';
+import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse, TechnicalAnalysis } from '../types/index.js';
+import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema, TechnicalAnalysisSchema } from './schemas.js';
 import type { ZodType } from 'zod';
 
 const API_KEY_ERROR_MESSAGE =
@@ -120,6 +120,19 @@ export async function getHistoricalData(
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
     console.error(`Failed to get historical data for asset ${assetId}:`, error);
+    return null;
+  }
+}
+
+export async function getTechnicalAnalysis(assetId: string): Promise<TechnicalAnalysis | null> {
+  try {
+    return await makeCoinCapRequest<TechnicalAnalysis>(
+      `/ta/${assetId}/allLatest`,
+      TechnicalAnalysisSchema
+    );
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(`Failed to get technical analysis for asset ${assetId}:`, error);
     return null;
   }
 }

--- a/src/services/formatters.ts
+++ b/src/services/formatters.ts
@@ -1,4 +1,4 @@
-import type { CryptoAsset, Market, HistoricalData } from '../types/index.js';
+import type { CryptoAsset, Market, HistoricalData, TechnicalAnalysis } from '../types/index.js';
 
 function formatPrice(value: number): string {
   if (value >= 1) return value.toFixed(2);
@@ -55,6 +55,56 @@ export function formatTopAssets(assets: CryptoAsset[]): string {
   });
 
   return ['Top Cryptocurrencies by Market Cap', '', ...lines].join('\n');
+}
+
+export function formatTechnicalAnalysis(asset: CryptoAsset, ta: TechnicalAnalysis): string {
+  const price = formatPrice(parseFloat(asset.priceUsd));
+
+  const smaLine = ta.sma
+    ? `  SMA (${ta.sma.period}): $${formatPrice(parseFloat(ta.sma.value))}`
+    : '  SMA: N/A';
+
+  const emaLine = ta.ema
+    ? `  EMA (${ta.ema.period}): $${formatPrice(parseFloat(ta.ema.value))}`
+    : '  EMA: N/A';
+
+  const rsiValue = ta.rsi ? parseFloat(ta.rsi.value) : null;
+  const rsiSignal = rsiValue === null ? 'N/A' : rsiValue > 70 ? 'Overbought' : rsiValue < 30 ? 'Oversold' : 'Neutral';
+  const rsiLine = ta.rsi
+    ? `  RSI (${ta.rsi.period}): ${parseFloat(ta.rsi.value).toFixed(2)} (${rsiSignal})`
+    : '  RSI: N/A';
+
+  const macdHistogram = ta.macd ? parseFloat(ta.macd.histogram) : null;
+  const macdSignalLabel = macdHistogram === null ? '' : macdHistogram > 0 ? ' (Bullish)' : ' (Bearish)';
+  const macdLines = ta.macd
+    ? [
+        `  Value: ${formatPrice(parseFloat(ta.macd.value))}`,
+        `  Signal: ${formatPrice(parseFloat(ta.macd.signal))}`,
+        `  Histogram: ${formatPrice(Math.abs(macdHistogram!))}${macdSignalLabel}`,
+      ].join('\n')
+    : '  MACD: N/A';
+
+  const vwapLine = ta.vwap
+    ? `  VWAP (24h): $${formatPrice(parseFloat(ta.vwap.value))}`
+    : '  VWAP: N/A';
+
+  return [
+    `Technical Analysis: ${asset.name} (${asset.symbol})`,
+    `Current Price: $${price}`,
+    '',
+    'Moving Averages:',
+    smaLine,
+    emaLine,
+    '',
+    'Momentum:',
+    rsiLine,
+    '',
+    'MACD:',
+    macdLines,
+    '',
+    'Volume:',
+    vwapLine,
+  ].join('\n');
 }
 
 export function formatHistoricalAnalysis(asset: CryptoAsset, history: HistoricalData['data']): string {

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -40,3 +40,36 @@ export const MarketSchema = z.object({
 export const MarketsResponseSchema = z.object({
   data: z.array(MarketSchema),
 });
+
+const SMASchema = z.object({
+  period: z.number(),
+  value: z.string(),
+}).nullable();
+
+const EMASchema = z.object({
+  period: z.number(),
+  value: z.string(),
+}).nullable();
+
+const RSISchema = z.object({
+  period: z.number(),
+  value: z.string(),
+}).nullable();
+
+const MACDSchema = z.object({
+  value: z.string(),
+  signal: z.string(),
+  histogram: z.string(),
+}).nullable();
+
+const VWAPSchema = z.object({
+  value: z.string(),
+}).nullable();
+
+export const TechnicalAnalysisSchema = z.object({
+  sma: SMASchema,
+  ema: EMASchema,
+  rsi: RSISchema,
+  macd: MACDSchema,
+  vwap: VWAPSchema,
+});

--- a/src/tools/__tests__/technical-analysis.test.ts
+++ b/src/tools/__tests__/technical-analysis.test.ts
@@ -1,0 +1,98 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getTechnicalAnalysis: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { searchAsset, getTechnicalAnalysis } = await import('../../services/coincap.js');
+const { handleGetTechnicalAnalysis } = await import('../technical-analysis.js');
+
+const mockSearchAsset = searchAsset as jest.MockedFunction<typeof searchAsset>;
+const mockGetTechnicalAnalysis = getTechnicalAnalysis as jest.MockedFunction<typeof getTechnicalAnalysis>;
+
+const mockAsset = {
+  id: 'bitcoin',
+  rank: '1',
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  priceUsd: '104232.50',
+  changePercent24Hr: '2.50',
+  volumeUsd24Hr: '30000000000',
+  marketCapUsd: '2050000000000',
+  supply: '19000000',
+  maxSupply: '21000000',
+  vwap24Hr: '103890.00',
+};
+
+const mockTa = {
+  sma: { period: 20, value: '102100.00' },
+  ema: { period: 20, value: '103450.00' },
+  rsi: { period: 14, value: '58.30' },
+  macd: { value: '1234.50', signal: '980.20', histogram: '254.30' },
+  vwap: { value: '103890.00' },
+};
+
+describe('handleGetTechnicalAnalysis', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return formatted technical analysis for a valid symbol', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce(mockTa);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('Technical Analysis: Bitcoin (BTC)');
+    expect(result.content[0].text).toContain('SMA');
+    expect(result.content[0].text).toContain('EMA');
+    expect(result.content[0].text).toContain('RSI');
+    expect(result.content[0].text).toContain('MACD');
+    expect(result.content[0].text).toContain('VWAP');
+  });
+
+  it('should return not-found message for unknown symbol', async () => {
+    mockSearchAsset.mockResolvedValueOnce(null);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'ZZZZZ' });
+    expect(result.content[0].text).toContain('Could not find cryptocurrency with symbol ZZZZZ');
+  });
+
+  it('should return error message when technical analysis data is null', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce(null);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('Failed to retrieve technical analysis');
+  });
+
+  it('should handle partial indicator data gracefully', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce({
+      sma: null,
+      ema: null,
+      rsi: { period: 14, value: '58.30' },
+      macd: null,
+      vwap: null,
+    });
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('RSI');
+    expect(result.content[0].text).toContain('N/A');
+  });
+
+  it('should return error message on exception', async () => {
+    mockSearchAsset.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('Network failure');
+  });
+
+  it('should throw on missing symbol', async () => {
+    await expect(handleGetTechnicalAnalysis({})).rejects.toThrow();
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,3 +2,4 @@ export * from './price.js';
 export * from './market.js';
 export * from './historical.js';
 export * from './top-assets.js';
+export * from './technical-analysis.js';

--- a/src/tools/technical-analysis.ts
+++ b/src/tools/technical-analysis.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { searchAsset, getTechnicalAnalysis } from '../services/coincap.js';
+import { formatTechnicalAnalysis } from '../services/formatters.js';
+
+export const GetTechnicalAnalysisSchema = z.object({
+  symbol: z.string().min(1).describe("Cryptocurrency symbol or name (e.g. BTC or Bitcoin)"),
+});
+
+export async function handleGetTechnicalAnalysis(args: unknown) {
+  const { symbol } = GetTechnicalAnalysisSchema.parse(args);
+  const upperSymbol = symbol.toUpperCase();
+
+  try {
+    const asset = await searchAsset(upperSymbol);
+
+    if (!asset) {
+      return {
+        content: [{ type: "text", text: `Could not find cryptocurrency with symbol ${upperSymbol}` }],
+      };
+    }
+
+    const ta = await getTechnicalAnalysis(asset.id);
+
+    if (!ta) {
+      return {
+        content: [{ type: "text", text: `Failed to retrieve technical analysis for ${asset.name} (${asset.symbol})` }],
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: formatTechnicalAnalysis(asset, ta) }],
+    };
+  } catch (error) {
+    return {
+      content: [{
+        type: "text",
+        text: error instanceof Error ? error.message : `Failed to retrieve technical analysis: ${String(error)}`
+      }],
+    };
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,3 +40,36 @@ export interface Market {
 export interface MarketsResponse {
   data: Market[];
 }
+
+export interface TechnicalAnalysisIndicatorSMA {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorEMA {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorRSI {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorMACD {
+  value: string;
+  signal: string;
+  histogram: string;
+}
+
+export interface TechnicalAnalysisIndicatorVWAP {
+  value: string;
+}
+
+export interface TechnicalAnalysis {
+  sma: TechnicalAnalysisIndicatorSMA | null;
+  ema: TechnicalAnalysisIndicatorEMA | null;
+  rsi: TechnicalAnalysisIndicatorRSI | null;
+  macd: TechnicalAnalysisIndicatorMACD | null;
+  vwap: TechnicalAnalysisIndicatorVWAP | null;
+}


### PR DESCRIPTION
## Summary

- Adds `get-technical-analysis` MCP tool using CoinCap `/ta/{slug}/allLatest` endpoint
- Returns SMA, EMA, RSI (with Overbought/Oversold/Neutral signal), MACD (with Bullish/Bearish signal), and 24h VWAP
- Gracefully handles null/missing indicators by displaying N/A
- Full unit test coverage following existing mock patterns (6 test cases)

## New Files

- `src/tools/technical-analysis.ts` — tool schema + handler
- `src/tools/__tests__/technical-analysis.test.ts` — unit tests

## Modified Files

- `src/types/index.ts` — added `TechnicalAnalysis` interface and sub-indicator types
- `src/services/schemas.ts` — added Zod schemas for TA response validation
- `src/services/coincap.ts` — added `getTechnicalAnalysis(assetId)` API function
- `src/services/formatters.ts` — added `formatTechnicalAnalysis(asset, ta)` formatter
- `src/tools/index.ts` — re-exported new tool
- `src/index.ts` — registered `get-technical-analysis` tool

## Test plan

- [ ] `npm test` — all 37 tests pass
- [ ] `npm run build` — TypeScript compiles without errors
- [ ] Verify `get-technical-analysis` appears in MCP tool list via `npm run inspector`