### PR TITLE
feat: add get-rates MCP tool for currency conversion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,12 @@ import {
   handleGetMarketAnalysis,
   handleGetHistoricalAnalysis,
   handleGetTopAssets,
+  handleGetRates,
   GetPriceArgumentsSchema,
   GetMarketAnalysisSchema,
   GetHistoricalAnalysisSchema,
   GetTopAssetsSchema,
+  GetRatesSchema,
 } from './tools/index.js';
 
 export const configSchema = z.object({
@@ -133,6 +135,26 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetTopAssets(args);
+      return result as any;
+    }
+  );
+
+  server.registerTool(
+    "get-rates",
+    {
+      title: "Get Currency Rates",
+      description: "Get USD-based conversion rates for fiat currencies and cryptocurrencies. Optionally pass a slug (e.g. 'euro', 'us-dollar', 'bitcoin') to look up a single rate.",
+      inputSchema: GetRatesSchema.shape,
+      annotations: {
+        title: "Get Currency Rates",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetRates(args);
       return result as any;
     }
   );

--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -1,6 +1,6 @@
 import { COINCAP_API_BASE, getCacheTtl } from '../config/index.js';
-import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse } from '../types/index.js';
-import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema } from './schemas.js';
+import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse, Rate, RateResponse, RatesResponse } from '../types/index.js';
+import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema, RateResponseSchema, RatesResponseSchema } from './schemas.js';
 import type { ZodType } from 'zod';
 
 const API_KEY_ERROR_MESSAGE =
@@ -102,6 +102,31 @@ export async function getMarkets(assetId: string): Promise<MarketsResponse | nul
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
     console.error(`Failed to get markets for asset ${assetId}:`, error);
+    return null;
+  }
+}
+
+export async function getRates(): Promise<Rate[] | null> {
+  try {
+    const response = await makeCoinCapRequest<RatesResponse>('/rates', RatesResponseSchema);
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error('Failed to get rates:', error);
+    return null;
+  }
+}
+
+export async function getRate(slug: string): Promise<Rate | null> {
+  try {
+    const response = await makeCoinCapRequest<RateResponse>(
+      `/rates/${encodeURIComponent(slug)}`,
+      RateResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(`Failed to get rate for ${slug}:`, error);
     return null;
   }
 }

--- a/src/services/formatters.ts
+++ b/src/services/formatters.ts
@@ -1,4 +1,4 @@
-import type { CryptoAsset, Market, HistoricalData } from '../types/index.js';
+import type { CryptoAsset, Market, HistoricalData, Rate } from '../types/index.js';
 
 function formatPrice(value: number): string {
   if (value >= 1) return value.toFixed(2);
@@ -55,6 +55,49 @@ export function formatTopAssets(assets: CryptoAsset[]): string {
   });
 
   return ['Top Cryptocurrencies by Market Cap', '', ...lines].join('\n');
+}
+
+export function formatRates(rates: Rate[]): string {
+  const fiatRates = rates.filter(r => r.type === 'fiat');
+  const cryptoRates = rates.filter(r => r.type === 'crypto');
+
+  const fiatLines = fiatRates.map(r => {
+    const symbol = r.currencySymbol ? ` ${r.currencySymbol}` : '';
+    const rate = parseFloat(r.rateUsd);
+    return `  ${r.symbol}${symbol}: $${rate < 1 ? rate.toFixed(6) : rate.toFixed(4)} USD`;
+  });
+
+  const cryptoLines = cryptoRates.slice(0, 10).map(r => {
+    const rate = parseFloat(r.rateUsd);
+    return `  ${r.symbol}: $${formatPrice(rate)} USD`;
+  });
+
+  return [
+    'Currency Conversion Rates (USD Base)',
+    '',
+    'Fiat Currencies:',
+    ...fiatLines,
+    '',
+    'Crypto Rates (Top 10):',
+    ...cryptoLines,
+  ].join('\n');
+}
+
+export function formatRate(rate: Rate): string {
+  const symbolLabel = rate.currencySymbol ? `${rate.symbol}  ${rate.currencySymbol}` : rate.symbol;
+  const rateValue = parseFloat(rate.rateUsd);
+  const formattedRate = rateValue < 1 ? rateValue.toFixed(6) : formatPrice(rateValue);
+  const name = rate.id
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  return [
+    `Rate: ${name} (${rate.symbol})`,
+    `Symbol: ${symbolLabel}`,
+    `Type: ${rate.type}`,
+    `Rate: $${formattedRate} USD`,
+  ].join('\n');
 }
 
 export function formatHistoricalAnalysis(asset: CryptoAsset, history: HistoricalData['data']): string {

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -40,3 +40,19 @@ export const MarketSchema = z.object({
 export const MarketsResponseSchema = z.object({
   data: z.array(MarketSchema),
 });
+
+export const RateSchema = z.object({
+  id: z.string(),
+  symbol: z.string(),
+  currencySymbol: z.string().nullable(),
+  type: z.string(),
+  rateUsd: z.string(),
+});
+
+export const RatesResponseSchema = z.object({
+  data: z.array(RateSchema),
+});
+
+export const RateResponseSchema = z.object({
+  data: RateSchema,
+});

--- a/src/tools/__tests__/rates.test.ts
+++ b/src/tools/__tests__/rates.test.ts
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getRates: jest.fn(),
+  getRate: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { getRates, getRate } = await import('../../services/coincap.js');
+const { handleGetRates } = await import('../rates.js');
+
+const mockGetRates = getRates as jest.MockedFunction<typeof getRates>;
+const mockGetRate = getRate as jest.MockedFunction<typeof getRate>;
+
+const mockRates = [
+  { id: 'us-dollar', symbol: 'USD', currencySymbol: '$', type: 'fiat', rateUsd: '1.0000' },
+  { id: 'euro', symbol: 'EUR', currencySymbol: '€', type: 'fiat', rateUsd: '0.9182' },
+  { id: 'british-pound', symbol: 'GBP', currencySymbol: '£', type: 'fiat', rateUsd: '1.2645' },
+  { id: 'bitcoin', symbol: 'BTC', currencySymbol: null, type: 'crypto', rateUsd: '104232.50' },
+  { id: 'ethereum', symbol: 'ETH', currencySymbol: null, type: 'crypto', rateUsd: '3210.45' },
+];
+
+const mockRate = { id: 'euro', symbol: 'EUR', currencySymbol: '€', type: 'fiat', rateUsd: '0.9182' };
+
+describe('handleGetRates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all rates when no slug is provided', async () => {
+    mockGetRates.mockResolvedValueOnce(mockRates);
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Currency Conversion Rates');
+    expect(result.content[0].text).toContain('Fiat');
+    expect(result.content[0].text).toContain('EUR');
+    expect(result.content[0].text).toContain('BTC');
+  });
+
+  it('should return a single rate when slug is provided', async () => {
+    mockGetRate.mockResolvedValueOnce(mockRate);
+
+    const result = await handleGetRates({ slug: 'euro' });
+    expect(result.content[0].text).toContain('Rate: Euro');
+    expect(result.content[0].text).toContain('EUR');
+    expect(result.content[0].text).toContain('0.9182');
+  });
+
+  it('should return error message when rates data is null', async () => {
+    mockGetRates.mockResolvedValueOnce(null);
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Failed to retrieve');
+  });
+
+  it('should return not-found message when single rate is null', async () => {
+    mockGetRate.mockResolvedValueOnce(null);
+
+    const result = await handleGetRates({ slug: 'unknown-currency' });
+    expect(result.content[0].text).toContain('Could not find rate for slug');
+  });
+
+  it('should handle fiat and crypto rates separately', async () => {
+    mockGetRates.mockResolvedValueOnce(mockRates);
+
+    const result = await handleGetRates({});
+    const text = result.content[0].text;
+    expect(text).toContain('Fiat');
+    expect(text).toContain('Crypto');
+  });
+
+  it('should return error message on exception', async () => {
+    mockGetRates.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Network failure');
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,3 +2,4 @@ export * from './price.js';
 export * from './market.js';
 export * from './historical.js';
 export * from './top-assets.js';
+export * from './rates.js';

--- a/src/tools/rates.ts
+++ b/src/tools/rates.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { getRates, getRate } from '../services/coincap.js';
+import { formatRates, formatRate } from '../services/formatters.js';
+
+export const GetRatesSchema = z.object({
+  slug: z.string().optional().describe("Optional: rate slug to fetch a single rate (e.g. 'us-dollar', 'euro', 'bitcoin')"),
+});
+
+export async function handleGetRates(args: unknown) {
+  const { slug } = GetRatesSchema.parse(args);
+
+  try {
+    if (slug) {
+      const rate = await getRate(slug);
+
+      if (!rate) {
+        return {
+          content: [{ type: "text", text: `Could not find rate for slug "${slug}". Try a slug like 'us-dollar', 'euro', or 'bitcoin'.` }],
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: formatRate(rate) }],
+      };
+    }
+
+    const rates = await getRates();
+
+    if (!rates) {
+      return {
+        content: [{ type: "text", text: "Failed to retrieve currency rates" }],
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: formatRates(rates) }],
+    };
+  } catch (error) {
+    return {
+      content: [{
+        type: "text",
+        text: error instanceof Error ? error.message : `Failed to retrieve rates: ${String(error)}`
+      }],
+    };
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,3 +40,19 @@ export interface Market {
 export interface MarketsResponse {
   data: Market[];
 }
+
+export interface Rate {
+  id: string;
+  symbol: string;
+  currencySymbol: string | null;
+  type: string;
+  rateUsd: string;
+}
+
+export interface RatesResponse {
+  data: Rate[];
+}
+
+export interface RateResponse {
+  data: Rate;
+}


### PR DESCRIPTION
## Summary

- Adds `get-rates` MCP tool using CoinCap `/rates` and `/rates/{slug}` endpoints
- Without a slug: returns all fiat currency rates + top 10 crypto rates grouped by type
- With a slug (e.g. `euro`, `us-dollar`, `bitcoin`): returns a single formatted rate
- Full unit test coverage with 6 test cases

## New Files

- `src/tools/rates.ts` — tool schema + handler
- `src/tools/__tests__/rates.test.ts` — unit tests

## Modified Files

- `src/types/index.ts` — added `Rate`, `RatesResponse`, `RateResponse` interfaces
- `src/services/schemas.ts` — added Zod schemas for rates response validation
- `src/services/coincap.ts` — added `getRates()` and `getRate(slug)` API functions
- `src/services/formatters.ts` — added `formatRates(rates)` and `formatRate(rate)` formatters
- `src/tools/index.ts` — re-exported new tool
- `src/index.ts` — registered `get-rates` tool

## Test plan

- [ ] `npm test` — all 37 tests pass
- [ ] `npm run build` — TypeScript compiles without errors
- [ ] Verify `get-rates` appears in MCP tool list via `npm run inspector`