### PR TITLE
feat: add get-exchanges MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 - **`src/services/formatters.ts`** — pure formatting functions for tool output text.
 - **`src/types/index.ts`** — shared TypeScript interfaces for CoinCap API responses.
 
-### Four registered MCP tools
+### Seven registered MCP tools
 
 | Tool | Handler | API endpoint |
 |------|---------|--------------|
@@ -64,6 +64,9 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 | `get-market-analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
 | `get-historical-analysis` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
 | `get-top-assets` | `handleGetTopAssets` | `/assets` |
+| `get-technical-analysis` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
+| `get-rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
+| `get-exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
 
 ### Releases & commits
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,30 @@ Lists top cryptocurrencies ranked by market cap, including:
 - Market cap and rank
 - Configurable result count (1–50, default 10)
 
+#### get-technical-analysis
+
+Returns the latest technical indicators for any cryptocurrency:
+- SMA (Simple Moving Average) with period
+- EMA (Exponential Moving Average) with period
+- RSI (Relative Strength Index) with Overbought/Oversold/Neutral signal
+- MACD with signal line, histogram, and Bullish/Bearish label
+- VWAP (Volume Weighted Average Price, 24h)
+
+#### get-rates
+
+Returns USD-based conversion rates for fiat currencies and cryptocurrencies:
+- All fiat currency rates (USD base)
+- Top 10 cryptocurrency rates
+- Optional `slug` parameter (e.g. `euro`, `bitcoin`) for a single rate lookup
+
+#### get-exchanges
+
+Lists top cryptocurrency exchanges ranked by 24h volume:
+- Exchange name, rank, and 24h volume in USD
+- Number of trading pairs and market share percentage
+- Optional `exchangeId` parameter (e.g. `binance`) for single exchange details
+- Optional `limit` parameter (1–50, default 10)
+
 ## Sample Prompts
 
 - "What's the current price of Bitcoin?"
@@ -193,6 +217,9 @@ Lists top cryptocurrencies ranked by market cap, including:
 - "Give me the 7-day price history for DOGE"
 - "What are the top exchanges trading BTC?"
 - "Show me the price trends for SOL with 1-hour intervals"
+- "What are the technical indicators for ETH right now?"
+- "What's the current EUR to USD exchange rate?"
+- "Which crypto exchanges have the highest 24h volume?"
 
 ## Project Inspiration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,12 @@ import {
   handleGetMarketAnalysis,
   handleGetHistoricalAnalysis,
   handleGetTopAssets,
+  handleGetExchanges,
   GetPriceArgumentsSchema,
   GetMarketAnalysisSchema,
   GetHistoricalAnalysisSchema,
   GetTopAssetsSchema,
+  GetExchangesSchema,
 } from './tools/index.js';
 
 export const configSchema = z.object({
@@ -133,6 +135,26 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetTopAssets(args);
+      return result as any;
+    }
+  );
+
+  server.registerTool(
+    "get-exchanges",
+    {
+      title: "Get Exchanges",
+      description: "Get top cryptocurrency exchanges ranked by 24h volume. Optionally pass an exchangeId (e.g. 'binance', 'coinbase') to get details for a specific exchange including volume, trading pairs, and market share.",
+      inputSchema: GetExchangesSchema.shape,
+      annotations: {
+        title: "Get Exchanges",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetExchanges(args);
       return result as any;
     }
   );

--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -1,6 +1,6 @@
 import { COINCAP_API_BASE, getCacheTtl } from '../config/index.js';
-import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse } from '../types/index.js';
-import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema } from './schemas.js';
+import type { AssetsResponse, CacheEntry, CryptoAsset, Exchange, ExchangeResponse, ExchangesResponse, HistoricalData, MarketsResponse } from '../types/index.js';
+import { AssetsResponseSchema, ExchangeResponseSchema, ExchangesResponseSchema, HistoricalDataSchema, MarketsResponseSchema } from './schemas.js';
 import type { ZodType } from 'zod';
 
 const API_KEY_ERROR_MESSAGE =
@@ -102,6 +102,34 @@ export async function getMarkets(assetId: string): Promise<MarketsResponse | nul
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
     console.error(`Failed to get markets for asset ${assetId}:`, error);
+    return null;
+  }
+}
+
+export async function getExchanges(limit: number = 10): Promise<Exchange[] | null> {
+  try {
+    const response = await makeCoinCapRequest<ExchangesResponse>(
+      `/exchanges?limit=${limit}`,
+      ExchangesResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error('Failed to get exchanges:', error);
+    return null;
+  }
+}
+
+export async function getExchange(exchangeId: string): Promise<Exchange | null> {
+  try {
+    const response = await makeCoinCapRequest<ExchangeResponse>(
+      `/exchanges/${encodeURIComponent(exchangeId)}`,
+      ExchangeResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(`Failed to get exchange ${exchangeId}:`, error);
     return null;
   }
 }

--- a/src/services/formatters.ts
+++ b/src/services/formatters.ts
@@ -1,4 +1,4 @@
-import type { CryptoAsset, Market, HistoricalData } from '../types/index.js';
+import type { CryptoAsset, Exchange, Market, HistoricalData } from '../types/index.js';
 
 function formatPrice(value: number): string {
   if (value >= 1) return value.toFixed(2);
@@ -55,6 +55,43 @@ export function formatTopAssets(assets: CryptoAsset[]): string {
   });
 
   return ['Top Cryptocurrencies by Market Cap', '', ...lines].join('\n');
+}
+
+export function formatExchanges(exchanges: Exchange[]): string {
+  const lines = exchanges.map(ex => {
+    const rank = ex.rank ? `#${ex.rank}` : 'N/A';
+    const volume = ex.volumeUsd
+      ? `$${(parseFloat(ex.volumeUsd) / 1_000_000_000).toFixed(2)}B`
+      : 'N/A';
+    const pairs = ex.tradingPairs ?? 'N/A';
+    const pct = ex.percentTotalVolume
+      ? `${parseFloat(ex.percentTotalVolume).toFixed(2)}% of total`
+      : '';
+    const ws = ex.socket ? '  WS' : '';
+    return `${rank.padEnd(4)} ${ex.name.padEnd(20)} ${volume.padEnd(12)} ${pairs} pairs${ws}  ${pct}`;
+  });
+
+  return ['Top Cryptocurrency Exchanges by Volume', '', ...lines].join('\n');
+}
+
+export function formatExchange(exchange: Exchange): string {
+  const volume = exchange.volumeUsd
+    ? `$${(parseFloat(exchange.volumeUsd) / 1_000_000_000).toFixed(2)}B USD`
+    : 'N/A';
+  const pairs = exchange.tradingPairs ?? 'N/A';
+  const pct = exchange.percentTotalVolume
+    ? `${parseFloat(exchange.percentTotalVolume).toFixed(2)}%`
+    : 'N/A';
+  const ws = exchange.socket === null ? 'N/A' : exchange.socket ? 'Yes' : 'No';
+
+  return [
+    `Exchange: ${exchange.name}`,
+    `Rank: #${exchange.rank}`,
+    `24h Volume: ${volume}`,
+    `Trading Pairs: ${pairs}`,
+    `% of Total Volume: ${pct}`,
+    `WebSocket: ${ws}`,
+  ].join('\n');
 }
 
 export function formatHistoricalAnalysis(asset: CryptoAsset, history: HistoricalData['data']): string {

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -40,3 +40,22 @@ export const MarketSchema = z.object({
 export const MarketsResponseSchema = z.object({
   data: z.array(MarketSchema),
 });
+
+export const ExchangeSchema = z.object({
+  exchangeId: z.string(),
+  name: z.string(),
+  rank: z.string(),
+  percentTotalVolume: z.string().nullable(),
+  volumeUsd: z.string().nullable(),
+  tradingPairs: z.string().nullable(),
+  socket: z.boolean().nullable(),
+  updated: z.number(),
+});
+
+export const ExchangesResponseSchema = z.object({
+  data: z.array(ExchangeSchema),
+});
+
+export const ExchangeResponseSchema = z.object({
+  data: ExchangeSchema,
+});

--- a/src/tools/__tests__/exchanges.test.ts
+++ b/src/tools/__tests__/exchanges.test.ts
@@ -1,0 +1,112 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getExchanges: jest.fn(),
+  getExchange: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { getExchanges, getExchange } = await import('../../services/coincap.js');
+const { handleGetExchanges } = await import('../exchanges.js');
+
+const mockGetExchanges = getExchanges as jest.MockedFunction<typeof getExchanges>;
+const mockGetExchange = getExchange as jest.MockedFunction<typeof getExchange>;
+
+const mockExchanges = [
+  {
+    exchangeId: 'binance',
+    name: 'Binance',
+    rank: '1',
+    percentTotalVolume: '35.20',
+    volumeUsd: '42300000000',
+    tradingPairs: '1234',
+    socket: true,
+    updated: 1700000000000,
+  },
+  {
+    exchangeId: 'coinbase',
+    name: 'Coinbase',
+    rank: '2',
+    percentTotalVolume: '19.10',
+    volumeUsd: '8100000000',
+    tradingPairs: '456',
+    socket: false,
+    updated: 1700000000000,
+  },
+];
+
+const mockExchange = {
+  exchangeId: 'binance',
+  name: 'Binance',
+  rank: '1',
+  percentTotalVolume: '35.20',
+  volumeUsd: '42300000000',
+  tradingPairs: '1234',
+  socket: true,
+  updated: 1700000000000,
+};
+
+describe('handleGetExchanges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return formatted exchange list when no exchangeId is provided', async () => {
+    mockGetExchanges.mockResolvedValueOnce(mockExchanges);
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Top Cryptocurrency Exchanges');
+    expect(result.content[0].text).toContain('Binance');
+    expect(result.content[0].text).toContain('Coinbase');
+  });
+
+  it('should return a single exchange when exchangeId is provided', async () => {
+    mockGetExchange.mockResolvedValueOnce(mockExchange);
+
+    const result = await handleGetExchanges({ exchangeId: 'binance' });
+    expect(result.content[0].text).toContain('Exchange: Binance');
+    expect(result.content[0].text).toContain('Rank: #1');
+    expect(result.content[0].text).toContain('42.30B');
+  });
+
+  it('should respect the limit parameter', async () => {
+    mockGetExchanges.mockResolvedValueOnce(mockExchanges);
+
+    const result = await handleGetExchanges({ limit: 1 });
+    expect(result.content[0].text).toContain('Binance');
+    expect(result.content[0].text).not.toContain('Coinbase');
+  });
+
+  it('should return error message when exchanges data is null', async () => {
+    mockGetExchanges.mockResolvedValueOnce(null);
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Failed to retrieve');
+  });
+
+  it('should return not-found message when single exchange is null', async () => {
+    mockGetExchange.mockResolvedValueOnce(null);
+
+    const result = await handleGetExchanges({ exchangeId: 'unknown-exchange' });
+    expect(result.content[0].text).toContain('Could not find exchange');
+  });
+
+  it('should return error message on exception', async () => {
+    mockGetExchanges.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Network failure');
+  });
+
+  it('should throw on invalid limit schema (below min)', async () => {
+    await expect(handleGetExchanges({ limit: 0 })).rejects.toThrow();
+  });
+
+  it('should throw on invalid limit schema (above max)', async () => {
+    await expect(handleGetExchanges({ limit: 51 })).rejects.toThrow();
+  });
+});

--- a/src/tools/exchanges.ts
+++ b/src/tools/exchanges.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { getExchanges, getExchange } from '../services/coincap.js';
+import { formatExchanges, formatExchange } from '../services/formatters.js';
+
+export const GetExchangesSchema = z.object({
+  exchangeId: z.string().optional().describe("Optional: specific exchange ID to look up (e.g. 'binance', 'coinbase', 'kraken')"),
+  limit: z.number().int().min(1).max(50).default(10).optional().describe("Number of top exchanges to return when listing (1-50, default 10)"),
+});
+
+export async function handleGetExchanges(args: unknown) {
+  const { exchangeId, limit = 10 } = GetExchangesSchema.parse(args);
+
+  try {
+    if (exchangeId) {
+      const exchange = await getExchange(exchangeId);
+
+      if (!exchange) {
+        return {
+          content: [{ type: "text", text: `Could not find exchange "${exchangeId}". Try an ID like 'binance', 'coinbase', or 'kraken'.` }],
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: formatExchange(exchange) }],
+      };
+    }
+
+    const exchanges = await getExchanges(limit);
+
+    if (!exchanges) {
+      return {
+        content: [{ type: "text", text: "Failed to retrieve exchanges" }],
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: formatExchanges(exchanges.slice(0, limit)) }],
+    };
+  } catch (error) {
+    return {
+      content: [{
+        type: "text",
+        text: error instanceof Error ? error.message : `Failed to retrieve exchanges: ${String(error)}`
+      }],
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,3 +2,4 @@ export * from './price.js';
 export * from './market.js';
 export * from './historical.js';
 export * from './top-assets.js';
+export * from './exchanges.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,3 +40,22 @@ export interface Market {
 export interface MarketsResponse {
   data: Market[];
 }
+
+export interface Exchange {
+  exchangeId: string;
+  name: string;
+  rank: string;
+  percentTotalVolume: string | null;
+  volumeUsd: string | null;
+  tradingPairs: string | null;
+  socket: boolean | null;
+  updated: number;
+}
+
+export interface ExchangesResponse {
+  data: Exchange[];
+}
+
+export interface ExchangeResponse {
+  data: Exchange;
+}


### PR DESCRIPTION
## Summary

- Adds `get-exchanges` MCP tool using CoinCap `/exchanges` and `/exchanges/{id}` endpoints
- Without an `exchangeId`: lists top exchanges ranked by 24h volume (respects `limit` param, 1-50, default 10)
- With an `exchangeId` (e.g. `binance`, `coinbase`): returns single exchange detail including volume, trading pairs, and market share
- Updates CLAUDE.md and README.md to document all three new tools added in this release cycle
- Full unit test coverage with 8 test cases

## New Files

- `src/tools/exchanges.ts` — tool schema + handler
- `src/tools/__tests__/exchanges.test.ts` — unit tests

## Modified Files

- `src/types/index.ts` — added `Exchange`, `ExchangesResponse`, `ExchangeResponse` interfaces
- `src/services/schemas.ts` — added Zod schemas for exchanges response validation
- `src/services/coincap.ts` — added `getExchanges(limit?)` and `getExchange(exchangeId)` API functions
- `src/services/formatters.ts` — added `formatExchanges(exchanges)` and `formatExchange(exchange)` formatters
- `src/tools/index.ts` — re-exported new tool
- `src/index.ts` — registered `get-exchanges` tool
- `CLAUDE.md` — updated tool table from 4 to 7 registered tools
- `README.md` — added documentation for get-technical-analysis, get-rates, and get-exchanges tools

## Test plan

- [ ] `npm test` — all 39 tests pass
- [ ] `npm run build` — TypeScript compiles without errors
- [ ] Verify `get-exchanges` appears in MCP tool list via `npm run inspector`