### PR TITLE
feat: add 3 new MCP tools, Prettier, ESLint, and type-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 !.yamllint.yaml
 !.configurations/
 !.releaserc.json
+!.prettierrc
+!.prettierignore
 
 # === Rules for root dir ===
 /core

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+coverage/
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ npm run start:stdio    # Start STDIO server (dist/index.js)
 npm test               # Run all tests
 npm run test:coverage  # Run tests with coverage
 
+# Lint & Format
+npm run lint           # Check for lint errors (ESLint + typescript-eslint)
+npm run lint:fix       # Auto-fix lint errors
+npm run format         # Format source files with Prettier
+npm run types:check    # TypeScript type-check without emitting files
+
 # Watch mode
 npm run watch          # TypeScript watch
 
@@ -56,7 +62,7 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 - **`src/services/formatters.ts`** — pure formatting functions for tool output text.
 - **`src/types/index.ts`** — shared TypeScript interfaces for CoinCap API responses.
 
-### Four registered MCP tools
+### Seven registered MCP tools
 
 | Tool | Handler | API endpoint |
 |------|---------|--------------|
@@ -64,6 +70,14 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 | `get-market-analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
 | `get-historical-analysis` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
 | `get-top-assets` | `handleGetTopAssets` | `/assets` |
+| `get-technical-analysis` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
+| `get-rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
+| `get-exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
+
+### Tooling
+
+- **Prettier** — code formatting (`npm run format`). Config: `.prettierrc`. Ignores: `.prettierignore`.
+- **ESLint** — linting with `typescript-eslint` (`npm run lint`). Config: `eslint.config.js`.
 
 ### Releases & commits
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ If your MCP client requires launching via `cmd.exe` on Windows:
 }
 ```
 
+### Development scripts
+
+```bash
+npm run build         # Compile TypeScript → dist/
+npm run format        # Format source files with Prettier
+npm run lint          # Check for lint errors (ESLint + typescript-eslint)
+npm run lint:fix      # Auto-fix lint errors
+npm run types:check   # TypeScript type-check without emitting files
+npm test              # Run all tests
+npm run test:coverage # Run tests with coverage report
+npm run inspector     # Open MCP inspector for interactive debugging
+```
+
 ### Run as Streamable HTTP server
 
 You can run the server over HTTP for environments that support MCP over HTTP streaming.
@@ -186,6 +199,30 @@ Lists top cryptocurrencies ranked by market cap, including:
 - Market cap and rank
 - Configurable result count (1–50, default 10)
 
+#### get-technical-analysis
+
+Returns the latest technical indicators for any cryptocurrency:
+- SMA (Simple Moving Average) with period
+- EMA (Exponential Moving Average) with period
+- RSI (Relative Strength Index) with Overbought/Oversold/Neutral signal
+- MACD with signal line, histogram, and Bullish/Bearish label
+- VWAP (Volume Weighted Average Price, 24h)
+
+#### get-rates
+
+Returns USD-based conversion rates for fiat currencies and cryptocurrencies:
+- All fiat currency rates (USD base)
+- Top 10 cryptocurrency rates
+- Optional `slug` parameter (e.g. `euro`, `bitcoin`) for a single rate lookup
+
+#### get-exchanges
+
+Lists top cryptocurrency exchanges ranked by 24h volume:
+- Exchange name, rank, and 24h volume in USD
+- Number of trading pairs and market share percentage
+- Optional `exchangeId` parameter (e.g. `binance`) for single exchange details
+- Optional `limit` parameter (1–50, default 10)
+
 ## Sample Prompts
 
 - "What's the current price of Bitcoin?"
@@ -193,6 +230,9 @@ Lists top cryptocurrencies ranked by market cap, including:
 - "Give me the 7-day price history for DOGE"
 - "What are the top exchanges trading BTC?"
 - "Show me the price trends for SOL with 1-hour intervals"
+- "What are the technical indicators for ETH right now?"
+- "What's the current EUR to USD exchange rate?"
+- "Which crypto exchanges have the highest 24h volume?"
 
 ## Project Inspiration
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+// @ts-check
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "mcp-crypto-price": "dist/index.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
@@ -23,11 +24,14 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.1",
         "conventional-changelog-conventionalcommits": "^9.1.0",
+        "eslint": "^10.2.0",
         "jest": "^30.3.0",
+        "prettier": "^3.8.2",
         "semantic-release": "^25.0.3",
         "shx": "^0.4.0",
         "ts-jest": "^29.4.6",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.58.1"
       },
       "engines": {
         "node": ">=22.14.0"
@@ -643,6 +647,134 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -653,6 +785,58 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2083,6 +2267,20 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2120,6 +2318,13 @@
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.12.2",
@@ -2161,6 +2366,236 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2449,6 +2884,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -3525,6 +3983,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3910,6 +4375,211 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3922,6 +4592,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -4114,6 +4830,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -4182,6 +4905,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -4261,6 +4997,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -4728,6 +5485,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
@@ -5773,6 +6540,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5798,6 +6572,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
@@ -5832,6 +6613,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5840,6 +6631,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8396,6 +9201,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -8849,6 +9672,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -8929,6 +9778,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
@@ -10677,6 +11536,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.4.9",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
@@ -10761,6 +11633,19 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -10810,6 +11695,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {
@@ -10974,6 +11883,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -11056,6 +11975,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "types:check": "tsc --noEmit",
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage",
     "prepublishOnly": "npm run build"
   },
@@ -33,6 +37,7 @@
     "zod": "^4.0.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
@@ -40,11 +45,14 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",
     "conventional-changelog-conventionalcommits": "^9.1.0",
+    "eslint": "^10.2.0",
     "jest": "^30.3.0",
+    "prettier": "^3.8.2",
     "semantic-release": "^25.0.3",
     "shx": "^0.4.0",
     "ts-jest": "^29.4.6",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.58.1"
   },
   "overrides": {
     "brace-expansion": "^5.0.5",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,17 +5,19 @@ import { dirname, resolve } from 'path';
 function readVersion(): string {
   try {
     const dir = dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(readFileSync(resolve(dir, '../../package.json'), 'utf-8'));
+    const pkg = JSON.parse(
+      readFileSync(resolve(dir, '../../package.json'), 'utf-8')
+    );
     return pkg.version;
   } catch {
     return '0.0.0';
   }
 }
 
-export const COINCAP_API_BASE = "https://rest.coincap.io/v3";
+export const COINCAP_API_BASE = 'https://rest.coincap.io/v3';
 
 export const SERVER_CONFIG = {
-  name: "mcp-crypto-price",
+  name: 'mcp-crypto-price',
   version: readVersion(),
 } as const;
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -8,9 +8,16 @@ import { renderHomepage } from './homepage.js';
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
 
-async function handleMcp(req: http.IncomingMessage, res: http.ServerResponse, searchParams: URLSearchParams) {
-  const coincapApiKey = searchParams.get('COINCAP_API_KEY') ?? process.env.COINCAP_API_KEY;
-  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+async function handleMcp(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  searchParams: URLSearchParams
+) {
+  const coincapApiKey =
+    searchParams.get('COINCAP_API_KEY') ?? process.env.COINCAP_API_KEY;
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
   const server = createServer({ config: { COINCAP_API_KEY: coincapApiKey } });
   await server.connect(transport);
 
@@ -38,7 +45,10 @@ const serverCard = {
       inputSchema: {
         type: 'object',
         properties: {
-          symbol: { type: 'string', description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)' },
+          symbol: {
+            type: 'string',
+            description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)',
+          },
         },
         required: ['symbol'],
       },
@@ -52,11 +62,15 @@ const serverCard = {
     },
     {
       name: 'get-market-analysis',
-      description: 'Get detailed market analysis including top exchanges and volume distribution',
+      description:
+        'Get detailed market analysis including top exchanges and volume distribution',
       inputSchema: {
         type: 'object',
         properties: {
-          symbol: { type: 'string', description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)' },
+          symbol: {
+            type: 'string',
+            description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)',
+          },
         },
         required: ['symbol'],
       },
@@ -74,12 +88,16 @@ const serverCard = {
       inputSchema: {
         type: 'object',
         properties: {
-          symbol: { type: 'string', description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)' },
+          symbol: {
+            type: 'string',
+            description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)',
+          },
           interval: {
             type: 'string',
             enum: ['m5', 'm15', 'm30', 'h1', 'h2', 'h6', 'h12', 'd1'],
             default: 'h1',
-            description: 'Data interval: m1=1min, m5=5min, m15=15min, m30=30min, h1=1hr, h2=2hr, h6=6hr, h12=12hr, d1=daily',
+            description:
+              'Data interval: m1=1min, m5=5min, m15=15min, m30=30min, h1=1hr, h2=2hr, h6=6hr, h12=12hr, d1=daily',
           },
           days: {
             type: 'number',
@@ -110,7 +128,8 @@ const serverCard = {
             minimum: 1,
             maximum: 50,
             default: 10,
-            description: 'Number of top assets to return, ranked by market cap (1-50)',
+            description:
+              'Number of top assets to return, ranked by market cap (1-50)',
           },
         },
       },
@@ -134,7 +153,8 @@ const serverCard = {
   prompts: [
     {
       name: 'analyze-crypto',
-      description: 'Generate a comprehensive analysis of a cryptocurrency covering price, market, and historical trends',
+      description:
+        'Generate a comprehensive analysis of a cryptocurrency covering price, market, and historical trends',
     },
   ],
 };
@@ -144,7 +164,10 @@ const httpServer = http.createServer(async (req, res) => {
   const pathname = parsed.pathname;
 
   // MCP server card for discovery (required by Smithery)
-  if (pathname === '/.well-known/mcp/server-card.json' && req.method === 'GET') {
+  if (
+    pathname === '/.well-known/mcp/server-card.json' &&
+    req.method === 'GET'
+  ) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(serverCard));
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,39 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/spec.types.js';
 
-import { z } from "zod";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { z } from 'zod';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { SERVER_CONFIG } from './config/index.js';
+
 import {
   handleGetPrice,
   handleGetMarketAnalysis,
   handleGetHistoricalAnalysis,
   handleGetTopAssets,
+  handleGetTechnicalAnalysis,
+  handleGetRates,
+  handleGetExchanges,
   GetPriceArgumentsSchema,
   GetMarketAnalysisSchema,
   GetHistoricalAnalysisSchema,
   GetTopAssetsSchema,
+  GetTechnicalAnalysisSchema,
+  GetRatesSchema,
+  GetExchangesSchema,
 } from './tools/index.js';
 
 export const configSchema = z.object({
   COINCAP_API_KEY: z
     .string()
     .optional()
-    .describe("API key for CoinCap v3 API. Free tier available at https://pro.coincap.io/dashboard"),
+    .describe(
+      'API key for CoinCap v3 API. Free tier available at https://pro.coincap.io/dashboard'
+    ),
   CACHE_TTL_SECONDS: z
     .number()
     .int()
@@ -31,7 +41,9 @@ export const configSchema = z.object({
     .max(3600)
     .default(60)
     .optional()
-    .describe("How long to cache API responses in seconds (default: 60). Lower values return fresher data; higher values reduce API usage."),
+    .describe(
+      'How long to cache API responses in seconds (default: 60). Lower values return fresher data; higher values reduce API usage.'
+    ),
 });
 
 export function createServer({
@@ -51,20 +63,21 @@ export function createServer({
     version: SERVER_CONFIG.version,
     icons: [
       {
-        src: "https://raw.githubusercontent.com/truss44/mcp-crypto-price/main/logo.png",
-        mimeType: "image/png",
+        src: 'https://raw.githubusercontent.com/truss44/mcp-crypto-price/main/logo.png',
+        mimeType: 'image/png',
       },
     ],
   });
 
   server.registerTool(
-    "get-crypto-price",
+    'get-crypto-price',
     {
-      title: "Get Crypto Price",
-      description: "Get real-time price, 24-hour change percentage, trading volume, and market cap for any cryptocurrency by symbol or name.",
+      title: 'Get Crypto Price',
+      description:
+        'Get real-time price, 24-hour change percentage, trading volume, and market cap for any cryptocurrency by symbol or name.',
       inputSchema: GetPriceArgumentsSchema.shape,
       annotations: {
-        title: "Get Crypto Price",
+        title: 'Get Crypto Price',
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -73,18 +86,19 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetPrice(args);
-      return result as any;
+      return result as unknown as CallToolResult;
     }
   );
 
   server.registerTool(
-    "get-market-analysis",
+    'get-market-analysis',
     {
-      title: "Get Market Analysis",
-      description: "Get detailed market analysis for a cryptocurrency including the top 5 exchanges by volume, price per exchange, and volume distribution percentages.",
+      title: 'Get Market Analysis',
+      description:
+        'Get detailed market analysis for a cryptocurrency including the top 5 exchanges by volume, price per exchange, and volume distribution percentages.',
       inputSchema: GetMarketAnalysisSchema.shape,
       annotations: {
-        title: "Get Market Analysis",
+        title: 'Get Market Analysis',
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -93,18 +107,19 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetMarketAnalysis(args);
-      return result as any;
+      return result as unknown as CallToolResult;
     }
   );
 
   server.registerTool(
-    "get-historical-analysis",
+    'get-historical-analysis',
     {
-      title: "Get Historical Analysis",
-      description: "Get historical price data for a cryptocurrency with trend analysis including period high/low, price change percentage, and volatility metrics over a customizable timeframe.",
+      title: 'Get Historical Analysis',
+      description:
+        'Get historical price data for a cryptocurrency with trend analysis including period high/low, price change percentage, and volatility metrics over a customizable timeframe.',
       inputSchema: GetHistoricalAnalysisSchema.shape,
       annotations: {
-        title: "Get Historical Analysis",
+        title: 'Get Historical Analysis',
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -113,18 +128,19 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetHistoricalAnalysis(args);
-      return result as any;
+      return result as unknown as CallToolResult;
     }
   );
 
   server.registerTool(
-    "get-top-assets",
+    'get-top-assets',
     {
-      title: "Get Top Assets",
-      description: "Get the top cryptocurrencies ranked by market cap, with real-time price, 24-hour change percentage, and market cap for each asset.",
+      title: 'Get Top Assets',
+      description:
+        'Get the top cryptocurrencies ranked by market cap, with real-time price, 24-hour change percentage, and market cap for each asset.',
       inputSchema: GetTopAssetsSchema.shape,
       annotations: {
-        title: "Get Top Assets",
+        title: 'Get Top Assets',
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -133,26 +149,91 @@ export function createServer({
     },
     async (args, _extra) => {
       const result = await handleGetTopAssets(args);
-      return result as any;
+      return result as unknown as CallToolResult;
+    }
+  );
+
+  server.registerTool(
+    'get-technical-analysis',
+    {
+      title: 'Get Technical Analysis',
+      description:
+        'Get the latest technical indicators for a cryptocurrency including SMA, EMA, RSI, MACD, and VWAP to assess momentum, trend direction, and overbought/oversold conditions.',
+      inputSchema: GetTechnicalAnalysisSchema.shape,
+      annotations: {
+        title: 'Get Technical Analysis',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetTechnicalAnalysis(args);
+      return result as unknown as CallToolResult;
+    }
+  );
+
+  server.registerTool(
+    'get-rates',
+    {
+      title: 'Get Currency Rates',
+      description:
+        "Get USD-based conversion rates for fiat currencies and cryptocurrencies. Optionally pass a slug (e.g. 'euro', 'us-dollar', 'bitcoin') to look up a single rate.",
+      inputSchema: GetRatesSchema.shape,
+      annotations: {
+        title: 'Get Currency Rates',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetRates(args);
+      return result as unknown as CallToolResult;
+    }
+  );
+
+  server.registerTool(
+    'get-exchanges',
+    {
+      title: 'Get Exchanges',
+      description:
+        "Get top cryptocurrency exchanges ranked by 24h volume. Optionally pass an exchangeId (e.g. 'binance', 'coinbase') to get details for a specific exchange including volume, trading pairs, and market share.",
+      inputSchema: GetExchangesSchema.shape,
+      annotations: {
+        title: 'Get Exchanges',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args, _extra) => {
+      const result = await handleGetExchanges(args);
+      return result as unknown as CallToolResult;
     }
   );
 
   server.registerPrompt(
-    "analyze-crypto",
+    'analyze-crypto',
     {
-      title: "Analyze Cryptocurrency",
+      title: 'Analyze Cryptocurrency',
       description:
-        "Generate a comprehensive analysis of a cryptocurrency covering price, market, and historical trends",
+        'Generate a comprehensive analysis of a cryptocurrency covering price, market, and historical trends',
       argsSchema: {
-        symbol: z.string().describe("Cryptocurrency symbol or name (e.g. BTC, ETH, Bitcoin)"),
+        symbol: z
+          .string()
+          .describe('Cryptocurrency symbol or name (e.g. BTC, ETH, Bitcoin)'),
       },
     },
     ({ symbol }) => ({
       messages: [
         {
-          role: "user",
+          role: 'user',
           content: {
-            type: "text",
+            type: 'text',
             text: `Please provide a comprehensive analysis of ${symbol}. Use the available tools to:
 1. Get the current price and 24-hour stats
 2. Analyze the top exchanges and trading volume distribution
@@ -169,18 +250,18 @@ Summarize the findings including price performance, market liquidity, and any no
   // during the MCP initialize handshake. Without this, clients may receive
   // -32601 "Method not found" errors for resources/list.
   server.registerResource(
-    "server-info",
-    "info://server",
+    'server-info',
+    'info://server',
     {
-      title: "Server Info",
-      description: "Basic server information",
-      mimeType: "application/json",
+      title: 'Server Info',
+      description: 'Basic server information',
+      mimeType: 'application/json',
     },
     async (uri) => ({
       contents: [
         {
           uri: uri.href,
-          mimeType: "application/json",
+          mimeType: 'application/json',
           text: JSON.stringify({
             name: SERVER_CONFIG.name,
             version: SERVER_CONFIG.version,
@@ -207,7 +288,7 @@ async function main() {
   });
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Crypto Price MCP Server running on stdio");
+  console.error('Crypto Price MCP Server running on stdio');
 }
 
 // Start stdio transport when:
@@ -215,8 +296,9 @@ async function main() {
 // 2. Run directly from CLI (not imported as a module)
 let thisFilePath: string | undefined;
 try {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const importMetaUrl = (import.meta as any)?.url;
-  if (typeof importMetaUrl === "string") {
+  if (typeof importMetaUrl === 'string') {
     thisFilePath = fileURLToPath(importMetaUrl);
   }
 } catch {
@@ -224,15 +306,16 @@ try {
 }
 
 const isEntrypoint =
-  typeof thisFilePath === "string" &&
-  typeof process.argv[1] === "string" &&
+  typeof thisFilePath === 'string' &&
+  typeof process.argv[1] === 'string' &&
   path.resolve(process.argv[1]) === path.resolve(thisFilePath);
 
-const isDirectRun = isEntrypoint || process.argv[1]?.includes('mcp-crypto-price');
+const isDirectRun =
+  isEntrypoint || process.argv[1]?.includes('mcp-crypto-price');
 
-if (process.env.MCP_TRANSPORT === "stdio" || isDirectRun) {
+if (process.env.MCP_TRANSPORT === 'stdio' || isDirectRun) {
   main().catch((error) => {
-    console.error("Fatal error in main():", error);
+    console.error('Fatal error in main():', error);
     process.exit(1);
   });
 }

--- a/src/services/__tests__/coincap.test.ts
+++ b/src/services/__tests__/coincap.test.ts
@@ -1,5 +1,11 @@
 import { jest } from '@jest/globals';
-import { getAssets, getMarkets, getHistoricalData, clearCache, MissingApiKeyError } from '../coincap.js';
+import {
+  getAssets,
+  getMarkets,
+  getHistoricalData,
+  clearCache,
+  MissingApiKeyError,
+} from '../coincap.js';
 
 // Mock global fetch
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
@@ -28,7 +34,9 @@ describe('CoinCap Service', () => {
       delete process.env.COINCAP_API_KEY;
 
       await expect(getAssets()).rejects.toThrow(MissingApiKeyError);
-      await expect(getAssets()).rejects.toThrow('https://pro.coincap.io/dashboard');
+      await expect(getAssets()).rejects.toThrow(
+        'https://pro.coincap.io/dashboard'
+      );
     });
   });
 
@@ -48,27 +56,31 @@ describe('CoinCap Service', () => {
             supply: '19000000',
             maxSupply: '21000000',
             vwap24Hr: '49500.00',
-          }
-        ]
+          },
+        ],
       };
 
-      mockFetch.mockImplementationOnce(() => Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockResponse)
-      } as Response));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse),
+        } as Response)
+      );
 
       const result = await getAssets();
       expect(result).toEqual(mockResponse);
       expect(mockFetch).toHaveBeenCalledWith(
         'https://rest.coincap.io/v3/assets',
         expect.objectContaining({
-          headers: { Authorization: 'Bearer test-api-key' }
+          headers: { Authorization: 'Bearer test-api-key' },
         })
       );
     });
 
     it('should handle fetch errors', async () => {
-      mockFetch.mockImplementationOnce(() => Promise.reject(new Error('Network error')));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.reject(new Error('Network error'))
+      );
 
       const result = await getAssets();
       expect(result).toBeNull();
@@ -76,11 +88,13 @@ describe('CoinCap Service', () => {
     });
 
     it('should handle non-ok response', async () => {
-      mockFetch.mockImplementationOnce(() => Promise.resolve({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error'
-      } as Response));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        } as Response)
+      );
 
       const result = await getAssets();
       expect(result).toBeNull();
@@ -99,27 +113,31 @@ describe('CoinCap Service', () => {
             priceUsd: '50000.00',
             volumeUsd24Hr: '5000000000',
             volumePercent: '25.00',
-          }
-        ]
+          },
+        ],
       };
 
-      mockFetch.mockImplementationOnce(() => Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockResponse)
-      } as Response));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse),
+        } as Response)
+      );
 
       const result = await getMarkets('bitcoin');
       expect(result).toEqual(mockResponse);
       expect(mockFetch).toHaveBeenCalledWith(
         'https://rest.coincap.io/v3/assets/bitcoin/markets',
         expect.objectContaining({
-          headers: { Authorization: 'Bearer test-api-key' }
+          headers: { Authorization: 'Bearer test-api-key' },
         })
       );
     });
 
     it('should handle fetch errors for markets', async () => {
-      mockFetch.mockImplementationOnce(() => Promise.reject(new Error('Network error')));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.reject(new Error('Network error'))
+      );
 
       const result = await getMarkets('bitcoin');
       expect(result).toBeNull();
@@ -134,30 +152,46 @@ describe('CoinCap Service', () => {
           {
             time: 1609459200000,
             priceUsd: '45000.00',
-            date: '2021-01-01'
-          }
-        ]
+            date: '2021-01-01',
+          },
+        ],
       };
 
-      mockFetch.mockImplementationOnce(() => Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockResponse)
-      } as Response));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse),
+        } as Response)
+      );
 
-      const result = await getHistoricalData('bitcoin', 'h1', 1609459200000, 1609545600000);
+      const result = await getHistoricalData(
+        'bitcoin',
+        'h1',
+        1609459200000,
+        1609545600000
+      );
       expect(result).toEqual(mockResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('https://rest.coincap.io/v3/assets/bitcoin/history'),
+        expect.stringContaining(
+          'https://rest.coincap.io/v3/assets/bitcoin/history'
+        ),
         expect.objectContaining({
-          headers: { Authorization: 'Bearer test-api-key' }
+          headers: { Authorization: 'Bearer test-api-key' },
         })
       );
     });
 
     it('should handle fetch errors for historical data', async () => {
-      mockFetch.mockImplementationOnce(() => Promise.reject(new Error('Network error')));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.reject(new Error('Network error'))
+      );
 
-      const result = await getHistoricalData('bitcoin', 'h1', 1609459200000, 1609545600000);
+      const result = await getHistoricalData(
+        'bitcoin',
+        'h1',
+        1609459200000,
+        1609545600000
+      );
       expect(result).toBeNull();
       expect(console.error).toHaveBeenCalled();
     });

--- a/src/services/__tests__/formatters.test.ts
+++ b/src/services/__tests__/formatters.test.ts
@@ -1,4 +1,8 @@
-import { formatPriceInfo, formatMarketAnalysis, formatHistoricalAnalysis } from '../formatters.js';
+import {
+  formatPriceInfo,
+  formatMarketAnalysis,
+  formatHistoricalAnalysis,
+} from '../formatters.js';
 import type { CryptoAsset, Market } from '../../types/index.js';
 
 describe('Formatters', () => {
@@ -15,7 +19,7 @@ describe('Formatters', () => {
         marketCapUsd: '1000000000000',
         supply: '19000000',
         maxSupply: '21000000',
-        vwap24Hr: '49500.00'
+        vwap24Hr: '49500.00',
       };
 
       const formatted = formatPriceInfo(asset);
@@ -39,7 +43,7 @@ describe('Formatters', () => {
         marketCapUsd: '7000000000',
         supply: '589000000000000',
         maxSupply: '',
-        vwap24Hr: '0.00001200'
+        vwap24Hr: '0.00001200',
       };
 
       const formatted = formatPriceInfo(asset);
@@ -61,7 +65,7 @@ describe('Formatters', () => {
         marketCapUsd: '1000000000000',
         supply: '19000000',
         maxSupply: '21000000',
-        vwap24Hr: '49500.00'
+        vwap24Hr: '49500.00',
       };
 
       const markets: Market[] = [
@@ -71,7 +75,7 @@ describe('Formatters', () => {
           quoteSymbol: 'USD',
           priceUsd: '50100.00',
           volumeUsd24Hr: '10000000000',
-          volumePercent: '33.33'
+          volumePercent: '33.33',
         },
         {
           exchangeId: 'coinbase',
@@ -79,8 +83,8 @@ describe('Formatters', () => {
           quoteSymbol: 'USD',
           priceUsd: '50000.00',
           volumeUsd24Hr: '8000000000',
-          volumePercent: '26.67'
-        }
+          volumePercent: '26.67',
+        },
       ];
 
       const formatted = formatMarketAnalysis(asset, markets);
@@ -106,7 +110,7 @@ describe('Formatters', () => {
         marketCapUsd: '1000000000000',
         supply: '19000000',
         maxSupply: '21000000',
-        vwap24Hr: '49500.00'
+        vwap24Hr: '49500.00',
       };
 
       const history = [
@@ -114,20 +118,20 @@ describe('Formatters', () => {
           time: 1609459200000,
           priceUsd: '45000.00',
           circulatingSupply: '18500000',
-          date: '2021-01-01'
+          date: '2021-01-01',
         },
         {
           time: 1609545600000,
           priceUsd: '48000.00',
           circulatingSupply: '18500000',
-          date: '2021-01-02'
+          date: '2021-01-02',
         },
         {
           time: 1609632000000,
           priceUsd: '50000.00',
           circulatingSupply: '18500000',
-          date: '2021-01-03'
-        }
+          date: '2021-01-03',
+        },
       ];
 
       const formatted = formatHistoricalAnalysis(asset, history);

--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -1,6 +1,28 @@
 import { COINCAP_API_BASE, getCacheTtl } from '../config/index.js';
-import type { AssetsResponse, CacheEntry, CryptoAsset, HistoricalData, MarketsResponse } from '../types/index.js';
-import { AssetsResponseSchema, HistoricalDataSchema, MarketsResponseSchema } from './schemas.js';
+import type {
+  AssetsResponse,
+  CacheEntry,
+  CryptoAsset,
+  Exchange,
+  ExchangeResponse,
+  ExchangesResponse,
+  HistoricalData,
+  MarketsResponse,
+  Rate,
+  RateResponse,
+  RatesResponse,
+  TechnicalAnalysis,
+} from '../types/index.js';
+import {
+  AssetsResponseSchema,
+  ExchangeResponseSchema,
+  ExchangesResponseSchema,
+  HistoricalDataSchema,
+  MarketsResponseSchema,
+  RateResponseSchema,
+  RatesResponseSchema,
+  TechnicalAnalysisSchema,
+} from './schemas.js';
 import type { ZodType } from 'zod';
 
 const API_KEY_ERROR_MESSAGE =
@@ -15,6 +37,7 @@ export class MissingApiKeyError extends Error {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const cache = new Map<string, CacheEntry<any>>();
 
 // Expose cache clear function for testing
@@ -38,11 +61,14 @@ function getCachedData<T>(key: string): T | null {
 function setCacheData<T>(key: string, data: T): void {
   cache.set(key, {
     data,
-    timestamp: Date.now()
+    timestamp: Date.now(),
   });
 }
 
-async function makeCoinCapRequest<T>(endpoint: string, schema?: ZodType<T>): Promise<T> {
+async function makeCoinCapRequest<T>(
+  endpoint: string,
+  schema?: ZodType<T>
+): Promise<T> {
   // Check cache first
   const cacheKey = endpoint;
   const cachedData = getCachedData<T>(cacheKey);
@@ -57,26 +83,31 @@ async function makeCoinCapRequest<T>(endpoint: string, schema?: ZodType<T>): Pro
 
   const response = await fetch(`${COINCAP_API_BASE}${endpoint}`, {
     headers: {
-      'Authorization': `Bearer ${apiKey}`
-    }
+      Authorization: `Bearer ${apiKey}`,
+    },
   });
 
   if (!response.ok) {
-    throw new Error(`CoinCap API error: ${response.status} - ${response.statusText}`);
+    throw new Error(
+      `CoinCap API error: ${response.status} - ${response.statusText}`
+    );
   }
 
   const raw = await response.json();
-  const data = schema ? schema.parse(raw) : raw as T;
+  const data = schema ? schema.parse(raw) : (raw as T);
   setCacheData(cacheKey, data);
   return data;
 }
 
 export async function getAssets(): Promise<AssetsResponse | null> {
   try {
-    return await makeCoinCapRequest<AssetsResponse>('/assets', AssetsResponseSchema);
+    return await makeCoinCapRequest<AssetsResponse>(
+      '/assets',
+      AssetsResponseSchema
+    );
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
-    console.error("Failed to get assets:", error);
+    console.error('Failed to get assets:', error);
     return null;
   }
 }
@@ -84,7 +115,10 @@ export async function getAssets(): Promise<AssetsResponse | null> {
 export async function searchAsset(symbol: string): Promise<CryptoAsset | null> {
   try {
     const upperSymbol = symbol.toUpperCase();
-    const data = await makeCoinCapRequest<AssetsResponse>(`/assets?search=${encodeURIComponent(symbol)}`, AssetsResponseSchema);
+    const data = await makeCoinCapRequest<AssetsResponse>(
+      `/assets?search=${encodeURIComponent(symbol)}`,
+      AssetsResponseSchema
+    );
     const asset =
       data.data.find((a) => a.symbol.toUpperCase() === upperSymbol) ??
       data.data.find((a) => a.name.toUpperCase() === upperSymbol);
@@ -96,9 +130,14 @@ export async function searchAsset(symbol: string): Promise<CryptoAsset | null> {
   }
 }
 
-export async function getMarkets(assetId: string): Promise<MarketsResponse | null> {
+export async function getMarkets(
+  assetId: string
+): Promise<MarketsResponse | null> {
   try {
-    return await makeCoinCapRequest<MarketsResponse>(`/assets/${assetId}/markets`, MarketsResponseSchema);
+    return await makeCoinCapRequest<MarketsResponse>(
+      `/assets/${assetId}/markets`,
+      MarketsResponseSchema
+    );
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
     console.error(`Failed to get markets for asset ${assetId}:`, error);
@@ -120,6 +159,84 @@ export async function getHistoricalData(
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
     console.error(`Failed to get historical data for asset ${assetId}:`, error);
+    return null;
+  }
+}
+
+export async function getTechnicalAnalysis(
+  assetId: string
+): Promise<TechnicalAnalysis | null> {
+  try {
+    return await makeCoinCapRequest<TechnicalAnalysis>(
+      `/ta/${assetId}/allLatest`,
+      TechnicalAnalysisSchema
+    );
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(
+      `Failed to get technical analysis for asset ${assetId}:`,
+      error
+    );
+    return null;
+  }
+}
+
+export async function getRates(): Promise<Rate[] | null> {
+  try {
+    const response = await makeCoinCapRequest<RatesResponse>(
+      '/rates',
+      RatesResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error('Failed to get rates:', error);
+    return null;
+  }
+}
+
+export async function getRate(slug: string): Promise<Rate | null> {
+  try {
+    const response = await makeCoinCapRequest<RateResponse>(
+      `/rates/${encodeURIComponent(slug)}`,
+      RateResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(`Failed to get rate for ${slug}:`, error);
+    return null;
+  }
+}
+
+export async function getExchanges(
+  limit: number = 10
+): Promise<Exchange[] | null> {
+  try {
+    const response = await makeCoinCapRequest<ExchangesResponse>(
+      `/exchanges?limit=${limit}`,
+      ExchangesResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error('Failed to get exchanges:', error);
+    return null;
+  }
+}
+
+export async function getExchange(
+  exchangeId: string
+): Promise<Exchange | null> {
+  try {
+    const response = await makeCoinCapRequest<ExchangeResponse>(
+      `/exchanges/${encodeURIComponent(exchangeId)}`,
+      ExchangeResponseSchema
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) throw error;
+    console.error(`Failed to get exchange ${exchangeId}:`, error);
     return null;
   }
 }

--- a/src/services/formatters.ts
+++ b/src/services/formatters.ts
@@ -1,4 +1,11 @@
-import type { CryptoAsset, Market, HistoricalData } from '../types/index.js';
+import type {
+  CryptoAsset,
+  Exchange,
+  HistoricalData,
+  Market,
+  Rate,
+  TechnicalAnalysis,
+} from '../types/index.js';
 
 function formatPrice(value: number): string {
   if (value >= 1) return value.toFixed(2);
@@ -11,8 +18,10 @@ export function formatPriceInfo(asset: CryptoAsset): string {
   const price = formatPrice(parseFloat(asset.priceUsd));
   const change = parseFloat(asset.changePercent24Hr || '0').toFixed(2);
   const volume = (parseFloat(asset.volumeUsd24Hr || '0') / 1000000).toFixed(2);
-  const marketCap = (parseFloat(asset.marketCapUsd || '0') / 1000000000).toFixed(2);
-  
+  const marketCap = (
+    parseFloat(asset.marketCapUsd || '0') / 1000000000
+  ).toFixed(2);
+
   return [
     `${asset.name} (${asset.symbol})`,
     `Price: $${price}`,
@@ -23,17 +32,28 @@ export function formatPriceInfo(asset: CryptoAsset): string {
   ].join('\n');
 }
 
-export function formatMarketAnalysis(asset: CryptoAsset, markets: Market[]): string {
-  const totalVolume = markets.reduce((sum, market) => sum + parseFloat(market.volumeUsd24Hr), 0);
+export function formatMarketAnalysis(
+  asset: CryptoAsset,
+  markets: Market[]
+): string {
+  const totalVolume = markets.reduce(
+    (sum, market) => sum + parseFloat(market.volumeUsd24Hr),
+    0
+  );
   const topMarkets = markets
     .sort((a, b) => parseFloat(b.volumeUsd24Hr) - parseFloat(a.volumeUsd24Hr))
     .slice(0, 5);
 
-  const marketInfo = topMarkets.map(market => {
-    const volumePercent = (parseFloat(market.volumeUsd24Hr) / totalVolume * 100).toFixed(2);
-    const volume = (parseFloat(market.volumeUsd24Hr) / 1000000).toFixed(2);
-    return `${market.exchangeId}: $${formatPrice(parseFloat(market.priceUsd))} (Volume: $${volume}M, ${volumePercent}% of total)`;
-  }).join('\n');
+  const marketInfo = topMarkets
+    .map((market) => {
+      const volumePercent = (
+        (parseFloat(market.volumeUsd24Hr) / totalVolume) *
+        100
+      ).toFixed(2);
+      const volume = (parseFloat(market.volumeUsd24Hr) / 1000000).toFixed(2);
+      return `${market.exchangeId}: $${formatPrice(parseFloat(market.priceUsd))} (Volume: $${volume}M, ${volumePercent}% of total)`;
+    })
+    .join('\n');
 
   return [
     `Market Analysis for ${asset.name} (${asset.symbol})`,
@@ -41,7 +61,7 @@ export function formatMarketAnalysis(asset: CryptoAsset, markets: Market[]): str
     `24h Volume: $${(parseFloat(asset.volumeUsd24Hr || '0') / 1000000).toFixed(2)}M`,
     `VWAP (24h): $${formatPrice(parseFloat(asset.vwap24Hr || '0'))}`,
     '\nTop 5 Markets by Volume:',
-    marketInfo
+    marketInfo,
   ].join('\n');
 }
 
@@ -49,7 +69,9 @@ export function formatTopAssets(assets: CryptoAsset[]): string {
   const lines = assets.map((asset) => {
     const price = formatPrice(parseFloat(asset.priceUsd));
     const change = parseFloat(asset.changePercent24Hr || '0').toFixed(2);
-    const marketCap = (parseFloat(asset.marketCapUsd || '0') / 1000000000).toFixed(2);
+    const marketCap = (
+      parseFloat(asset.marketCapUsd || '0') / 1000000000
+    ).toFixed(2);
     const rankStr = asset.rank != null ? `#${asset.rank} ` : '';
     return `${rankStr}${asset.name} (${asset.symbol}): $${price} (24h: ${change}%, MCap: $${marketCap}B)`;
   });
@@ -57,12 +79,166 @@ export function formatTopAssets(assets: CryptoAsset[]): string {
   return ['Top Cryptocurrencies by Market Cap', '', ...lines].join('\n');
 }
 
-export function formatHistoricalAnalysis(asset: CryptoAsset, history: HistoricalData['data']): string {
+export function formatTechnicalAnalysis(
+  asset: CryptoAsset,
+  ta: TechnicalAnalysis
+): string {
+  const price = formatPrice(parseFloat(asset.priceUsd));
+
+  const smaLine = ta.sma
+    ? `  SMA (${ta.sma.period}): $${formatPrice(parseFloat(ta.sma.value))}`
+    : '  SMA: N/A';
+
+  const emaLine = ta.ema
+    ? `  EMA (${ta.ema.period}): $${formatPrice(parseFloat(ta.ema.value))}`
+    : '  EMA: N/A';
+
+  const rsiValue = ta.rsi ? parseFloat(ta.rsi.value) : null;
+  const rsiSignal =
+    rsiValue === null
+      ? 'N/A'
+      : rsiValue > 70
+        ? 'Overbought'
+        : rsiValue < 30
+          ? 'Oversold'
+          : 'Neutral';
+  const rsiLine = ta.rsi
+    ? `  RSI (${ta.rsi.period}): ${parseFloat(ta.rsi.value).toFixed(2)} (${rsiSignal})`
+    : '  RSI: N/A';
+
+  const macdHistogram = ta.macd ? parseFloat(ta.macd.histogram) : null;
+  const macdSignalLabel =
+    macdHistogram === null
+      ? ''
+      : macdHistogram > 0
+        ? ' (Bullish)'
+        : ' (Bearish)';
+  const macdLines = ta.macd
+    ? [
+        `  Value: ${formatPrice(parseFloat(ta.macd.value))}`,
+        `  Signal: ${formatPrice(parseFloat(ta.macd.signal))}`,
+        `  Histogram: ${formatPrice(Math.abs(macdHistogram!))}${macdSignalLabel}`,
+      ].join('\n')
+    : '  MACD: N/A';
+
+  const vwapLine = ta.vwap
+    ? `  VWAP (24h): $${formatPrice(parseFloat(ta.vwap.value))}`
+    : '  VWAP: N/A';
+
+  return [
+    `Technical Analysis: ${asset.name} (${asset.symbol})`,
+    `Current Price: $${price}`,
+    '',
+    'Moving Averages:',
+    smaLine,
+    emaLine,
+    '',
+    'Momentum:',
+    rsiLine,
+    '',
+    'MACD:',
+    macdLines,
+    '',
+    'Volume:',
+    vwapLine,
+  ].join('\n');
+}
+
+export function formatRates(rates: Rate[]): string {
+  const fiatRates = rates.filter((r) => r.type === 'fiat');
+  const cryptoRates = rates.filter((r) => r.type === 'crypto');
+
+  const fiatLines = fiatRates.map((r) => {
+    const symbol = r.currencySymbol ? ` ${r.currencySymbol}` : '';
+    const rate = parseFloat(r.rateUsd);
+    return `  ${r.symbol}${symbol}: $${rate < 1 ? rate.toFixed(6) : rate.toFixed(4)} USD`;
+  });
+
+  const cryptoLines = cryptoRates.slice(0, 10).map((r) => {
+    const rate = parseFloat(r.rateUsd);
+    return `  ${r.symbol}: $${formatPrice(rate)} USD`;
+  });
+
+  return [
+    'Currency Conversion Rates (USD Base)',
+    '',
+    'Fiat Currencies:',
+    ...fiatLines,
+    '',
+    'Crypto Rates (Top 10):',
+    ...cryptoLines,
+  ].join('\n');
+}
+
+export function formatRate(rate: Rate): string {
+  const symbolLabel = rate.currencySymbol
+    ? `${rate.symbol}  ${rate.currencySymbol}`
+    : rate.symbol;
+  const rateValue = parseFloat(rate.rateUsd);
+  const formattedRate =
+    rateValue < 1 ? rateValue.toFixed(6) : formatPrice(rateValue);
+  const name = rate.id
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  return [
+    `Rate: ${name} (${rate.symbol})`,
+    `Symbol: ${symbolLabel}`,
+    `Type: ${rate.type}`,
+    `Rate: $${formattedRate} USD`,
+  ].join('\n');
+}
+
+export function formatExchanges(exchanges: Exchange[]): string {
+  const lines = exchanges.map((ex) => {
+    const rank = ex.rank ? `#${ex.rank}` : 'N/A';
+    const volume = ex.volumeUsd
+      ? `$${(parseFloat(ex.volumeUsd) / 1_000_000_000).toFixed(2)}B`
+      : 'N/A';
+    const pairs = ex.tradingPairs ?? 'N/A';
+    const pct = ex.percentTotalVolume
+      ? `${parseFloat(ex.percentTotalVolume).toFixed(2)}% of total`
+      : '';
+    const ws = ex.socket ? '  WS' : '';
+    return `${rank.padEnd(4)} ${ex.name.padEnd(20)} ${volume.padEnd(12)} ${pairs} pairs${ws}  ${pct}`;
+  });
+
+  return ['Top Cryptocurrency Exchanges by Volume', '', ...lines].join('\n');
+}
+
+export function formatExchange(exchange: Exchange): string {
+  const volume = exchange.volumeUsd
+    ? `$${(parseFloat(exchange.volumeUsd) / 1_000_000_000).toFixed(2)}B USD`
+    : 'N/A';
+  const pairs = exchange.tradingPairs ?? 'N/A';
+  const pct = exchange.percentTotalVolume
+    ? `${parseFloat(exchange.percentTotalVolume).toFixed(2)}%`
+    : 'N/A';
+  const ws = exchange.socket === null ? 'N/A' : exchange.socket ? 'Yes' : 'No';
+
+  return [
+    `Exchange: ${exchange.name}`,
+    `Rank: #${exchange.rank}`,
+    `24h Volume: ${volume}`,
+    `Trading Pairs: ${pairs}`,
+    `% of Total Volume: ${pct}`,
+    `WebSocket: ${ws}`,
+  ].join('\n');
+}
+
+export function formatHistoricalAnalysis(
+  asset: CryptoAsset,
+  history: HistoricalData['data']
+): string {
   const currentPrice = parseFloat(asset.priceUsd);
   const oldestPrice = parseFloat(history[0].priceUsd);
-  const highestPrice = Math.max(...history.map(h => parseFloat(h.priceUsd)));
-  const lowestPrice = Math.min(...history.map(h => parseFloat(h.priceUsd)));
-  const priceChange = ((currentPrice - oldestPrice) / oldestPrice * 100).toFixed(2);
+  const highestPrice = Math.max(...history.map((h) => parseFloat(h.priceUsd)));
+  const lowestPrice = Math.min(...history.map((h) => parseFloat(h.priceUsd)));
+  const priceChange = (
+    ((currentPrice - oldestPrice) / oldestPrice) *
+    100
+  ).toFixed(2);
 
   return [
     `Historical Analysis for ${asset.name} (${asset.symbol})`,
@@ -73,6 +249,6 @@ export function formatHistoricalAnalysis(asset: CryptoAsset, history: Historical
     `Starting Price: $${formatPrice(oldestPrice)}`,
     '\nVolatility Analysis:',
     `Price Range: $${formatPrice(highestPrice - lowestPrice)}`,
-    `Range Percentage: ${((highestPrice - lowestPrice) / lowestPrice * 100).toFixed(2)}%`
+    `Range Percentage: ${(((highestPrice - lowestPrice) / lowestPrice) * 100).toFixed(2)}%`,
   ].join('\n');
 }

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -40,3 +40,81 @@ export const MarketSchema = z.object({
 export const MarketsResponseSchema = z.object({
   data: z.array(MarketSchema),
 });
+
+const SMASchema = z
+  .object({
+    period: z.number(),
+    value: z.string(),
+  })
+  .nullable();
+
+const EMASchema = z
+  .object({
+    period: z.number(),
+    value: z.string(),
+  })
+  .nullable();
+
+const RSISchema = z
+  .object({
+    period: z.number(),
+    value: z.string(),
+  })
+  .nullable();
+
+const MACDSchema = z
+  .object({
+    value: z.string(),
+    signal: z.string(),
+    histogram: z.string(),
+  })
+  .nullable();
+
+const VWAPSchema = z
+  .object({
+    value: z.string(),
+  })
+  .nullable();
+
+export const TechnicalAnalysisSchema = z.object({
+  sma: SMASchema,
+  ema: EMASchema,
+  rsi: RSISchema,
+  macd: MACDSchema,
+  vwap: VWAPSchema,
+});
+
+export const RateSchema = z.object({
+  id: z.string(),
+  symbol: z.string(),
+  currencySymbol: z.string().nullable(),
+  type: z.string(),
+  rateUsd: z.string(),
+});
+
+export const RatesResponseSchema = z.object({
+  data: z.array(RateSchema),
+});
+
+export const RateResponseSchema = z.object({
+  data: RateSchema,
+});
+
+export const ExchangeSchema = z.object({
+  exchangeId: z.string(),
+  name: z.string(),
+  rank: z.string(),
+  percentTotalVolume: z.string().nullable(),
+  volumeUsd: z.string().nullable(),
+  tradingPairs: z.string().nullable(),
+  socket: z.boolean().nullable(),
+  updated: z.number(),
+});
+
+export const ExchangesResponseSchema = z.object({
+  data: z.array(ExchangeSchema),
+});
+
+export const ExchangeResponseSchema = z.object({
+  data: ExchangeSchema,
+});

--- a/src/tools/__tests__/exchanges.test.ts
+++ b/src/tools/__tests__/exchanges.test.ts
@@ -1,0 +1,114 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getExchanges: jest.fn(),
+  getExchange: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { getExchanges, getExchange } = await import('../../services/coincap.js');
+const { handleGetExchanges } = await import('../exchanges.js');
+
+const mockGetExchanges = getExchanges as jest.MockedFunction<
+  typeof getExchanges
+>;
+const mockGetExchange = getExchange as jest.MockedFunction<typeof getExchange>;
+
+const mockExchanges = [
+  {
+    exchangeId: 'binance',
+    name: 'Binance',
+    rank: '1',
+    percentTotalVolume: '35.20',
+    volumeUsd: '42300000000',
+    tradingPairs: '1234',
+    socket: true,
+    updated: 1700000000000,
+  },
+  {
+    exchangeId: 'coinbase',
+    name: 'Coinbase',
+    rank: '2',
+    percentTotalVolume: '19.10',
+    volumeUsd: '8100000000',
+    tradingPairs: '456',
+    socket: false,
+    updated: 1700000000000,
+  },
+];
+
+const mockExchange = {
+  exchangeId: 'binance',
+  name: 'Binance',
+  rank: '1',
+  percentTotalVolume: '35.20',
+  volumeUsd: '42300000000',
+  tradingPairs: '1234',
+  socket: true,
+  updated: 1700000000000,
+};
+
+describe('handleGetExchanges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return formatted exchange list when no exchangeId is provided', async () => {
+    mockGetExchanges.mockResolvedValueOnce(mockExchanges);
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Top Cryptocurrency Exchanges');
+    expect(result.content[0].text).toContain('Binance');
+    expect(result.content[0].text).toContain('Coinbase');
+  });
+
+  it('should return a single exchange when exchangeId is provided', async () => {
+    mockGetExchange.mockResolvedValueOnce(mockExchange);
+
+    const result = await handleGetExchanges({ exchangeId: 'binance' });
+    expect(result.content[0].text).toContain('Exchange: Binance');
+    expect(result.content[0].text).toContain('Rank: #1');
+    expect(result.content[0].text).toContain('42.30B');
+  });
+
+  it('should respect the limit parameter', async () => {
+    mockGetExchanges.mockResolvedValueOnce(mockExchanges);
+
+    const result = await handleGetExchanges({ limit: 1 });
+    expect(result.content[0].text).toContain('Binance');
+    expect(result.content[0].text).not.toContain('Coinbase');
+  });
+
+  it('should return error message when exchanges data is null', async () => {
+    mockGetExchanges.mockResolvedValueOnce(null);
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Failed to retrieve');
+  });
+
+  it('should return not-found message when single exchange is null', async () => {
+    mockGetExchange.mockResolvedValueOnce(null);
+
+    const result = await handleGetExchanges({ exchangeId: 'unknown-exchange' });
+    expect(result.content[0].text).toContain('Could not find exchange');
+  });
+
+  it('should return error message on exception', async () => {
+    mockGetExchanges.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetExchanges({});
+    expect(result.content[0].text).toContain('Network failure');
+  });
+
+  it('should throw on invalid limit schema (below min)', async () => {
+    await expect(handleGetExchanges({ limit: 0 })).rejects.toThrow();
+  });
+
+  it('should throw on invalid limit schema (above max)', async () => {
+    await expect(handleGetExchanges({ limit: 51 })).rejects.toThrow();
+  });
+});

--- a/src/tools/__tests__/historical.test.ts
+++ b/src/tools/__tests__/historical.test.ts
@@ -8,17 +8,27 @@ jest.unstable_mockModule('../../services/coincap.js', () => ({
   clearCache: jest.fn(),
 }));
 
-const { searchAsset, getHistoricalData } = await import('../../services/coincap.js');
+const { searchAsset, getHistoricalData } =
+  await import('../../services/coincap.js');
 const { handleGetHistoricalAnalysis } = await import('../historical.js');
 
 const mockSearchAsset = searchAsset as jest.MockedFunction<typeof searchAsset>;
-const mockGetHistoricalData = getHistoricalData as jest.MockedFunction<typeof getHistoricalData>;
+const mockGetHistoricalData = getHistoricalData as jest.MockedFunction<
+  typeof getHistoricalData
+>;
 
 const mockAsset = {
-  id: 'bitcoin', rank: '1', symbol: 'BTC', name: 'Bitcoin',
-  priceUsd: '50000.00', changePercent24Hr: '2.50',
-  volumeUsd24Hr: '30000000000', marketCapUsd: '950000000000',
-  supply: '19000000', maxSupply: '21000000', vwap24Hr: '49500.00',
+  id: 'bitcoin',
+  rank: '1',
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  priceUsd: '50000.00',
+  changePercent24Hr: '2.50',
+  volumeUsd24Hr: '30000000000',
+  marketCapUsd: '950000000000',
+  supply: '19000000',
+  maxSupply: '21000000',
+  vwap24Hr: '49500.00',
 };
 
 describe('handleGetHistoricalAnalysis', () => {
@@ -44,7 +54,9 @@ describe('handleGetHistoricalAnalysis', () => {
     mockSearchAsset.mockResolvedValueOnce(null);
 
     const result = await handleGetHistoricalAnalysis({ symbol: 'ZZZZZ' });
-    expect(result.content[0].text).toContain('Could not find cryptocurrency with symbol ZZZZZ');
+    expect(result.content[0].text).toContain(
+      'Could not find cryptocurrency with symbol ZZZZZ'
+    );
   });
 
   it('should return error when historical data is null', async () => {
@@ -60,14 +72,20 @@ describe('handleGetHistoricalAnalysis', () => {
     mockGetHistoricalData.mockResolvedValueOnce({ data: [] });
 
     const result = await handleGetHistoricalAnalysis({ symbol: 'BTC' });
-    expect(result.content[0].text).toBe('No historical data available for the selected time period');
+    expect(result.content[0].text).toBe(
+      'No historical data available for the selected time period'
+    );
   });
 
   it('should clamp days to schema bounds', async () => {
     // days > 30 should fail schema validation
-    await expect(handleGetHistoricalAnalysis({ symbol: 'BTC', days: 100 })).rejects.toThrow();
+    await expect(
+      handleGetHistoricalAnalysis({ symbol: 'BTC', days: 100 })
+    ).rejects.toThrow();
     // days < 1 should fail schema validation
-    await expect(handleGetHistoricalAnalysis({ symbol: 'BTC', days: 0 })).rejects.toThrow();
+    await expect(
+      handleGetHistoricalAnalysis({ symbol: 'BTC', days: 0 })
+    ).rejects.toThrow();
   });
 
   it('should throw on missing symbol', async () => {

--- a/src/tools/__tests__/market.test.ts
+++ b/src/tools/__tests__/market.test.ts
@@ -15,10 +15,17 @@ const mockSearchAsset = searchAsset as jest.MockedFunction<typeof searchAsset>;
 const mockGetMarkets = getMarkets as jest.MockedFunction<typeof getMarkets>;
 
 const mockAsset = {
-  id: 'bitcoin', rank: '1', symbol: 'BTC', name: 'Bitcoin',
-  priceUsd: '50000.00', changePercent24Hr: '2.50',
-  volumeUsd24Hr: '30000000000', marketCapUsd: '950000000000',
-  supply: '19000000', maxSupply: '21000000', vwap24Hr: '49500.00',
+  id: 'bitcoin',
+  rank: '1',
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  priceUsd: '50000.00',
+  changePercent24Hr: '2.50',
+  volumeUsd24Hr: '30000000000',
+  marketCapUsd: '950000000000',
+  supply: '19000000',
+  maxSupply: '21000000',
+  vwap24Hr: '49500.00',
 };
 
 describe('handleGetMarketAnalysis', () => {
@@ -29,11 +36,16 @@ describe('handleGetMarketAnalysis', () => {
   it('should return formatted market analysis for a valid symbol', async () => {
     mockSearchAsset.mockResolvedValueOnce(mockAsset);
     mockGetMarkets.mockResolvedValueOnce({
-      data: [{
-        exchangeId: 'binance', baseSymbol: 'BTC', quoteSymbol: 'USDT',
-        priceUsd: '50000.00', volumeUsd24Hr: '5000000000',
-        volumePercent: '25.00',
-      }],
+      data: [
+        {
+          exchangeId: 'binance',
+          baseSymbol: 'BTC',
+          quoteSymbol: 'USDT',
+          priceUsd: '50000.00',
+          volumeUsd24Hr: '5000000000',
+          volumePercent: '25.00',
+        },
+      ],
     });
 
     const result = await handleGetMarketAnalysis({ symbol: 'BTC' });
@@ -45,7 +57,9 @@ describe('handleGetMarketAnalysis', () => {
     mockSearchAsset.mockResolvedValueOnce(null);
 
     const result = await handleGetMarketAnalysis({ symbol: 'ZZZZZ' });
-    expect(result.content[0].text).toContain('Could not find cryptocurrency with symbol ZZZZZ');
+    expect(result.content[0].text).toContain(
+      'Could not find cryptocurrency with symbol ZZZZZ'
+    );
   });
 
   it('should return error when markets data is null', async () => {

--- a/src/tools/__tests__/price.test.ts
+++ b/src/tools/__tests__/price.test.ts
@@ -20,10 +20,17 @@ describe('handleGetPrice', () => {
 
   it('should return formatted price for a valid symbol', async () => {
     mockSearchAsset.mockResolvedValueOnce({
-      id: 'bitcoin', rank: '1', symbol: 'BTC', name: 'Bitcoin',
-      priceUsd: '50000.00', changePercent24Hr: '2.50',
-      volumeUsd24Hr: '30000000000', marketCapUsd: '950000000000',
-      supply: '19000000', maxSupply: '21000000', vwap24Hr: '49500.00',
+      id: 'bitcoin',
+      rank: '1',
+      symbol: 'BTC',
+      name: 'Bitcoin',
+      priceUsd: '50000.00',
+      changePercent24Hr: '2.50',
+      volumeUsd24Hr: '30000000000',
+      marketCapUsd: '950000000000',
+      supply: '19000000',
+      maxSupply: '21000000',
+      vwap24Hr: '49500.00',
     });
 
     const result = await handleGetPrice({ symbol: 'BTC' });
@@ -35,7 +42,9 @@ describe('handleGetPrice', () => {
     mockSearchAsset.mockResolvedValueOnce(null);
 
     const result = await handleGetPrice({ symbol: 'ZZZZZ' });
-    expect(result.content[0].text).toContain('Could not find cryptocurrency with symbol ZZZZZ');
+    expect(result.content[0].text).toContain(
+      'Could not find cryptocurrency with symbol ZZZZZ'
+    );
   });
 
   it('should return error message on exception', async () => {

--- a/src/tools/__tests__/rates.test.ts
+++ b/src/tools/__tests__/rates.test.ts
@@ -1,0 +1,118 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getRates: jest.fn(),
+  getRate: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { getRates, getRate } = await import('../../services/coincap.js');
+const { handleGetRates } = await import('../rates.js');
+
+const mockGetRates = getRates as jest.MockedFunction<typeof getRates>;
+const mockGetRate = getRate as jest.MockedFunction<typeof getRate>;
+
+const mockRates = [
+  {
+    id: 'us-dollar',
+    symbol: 'USD',
+    currencySymbol: '$',
+    type: 'fiat',
+    rateUsd: '1.0000',
+  },
+  {
+    id: 'euro',
+    symbol: 'EUR',
+    currencySymbol: '€',
+    type: 'fiat',
+    rateUsd: '0.9182',
+  },
+  {
+    id: 'british-pound',
+    symbol: 'GBP',
+    currencySymbol: '£',
+    type: 'fiat',
+    rateUsd: '1.2645',
+  },
+  {
+    id: 'bitcoin',
+    symbol: 'BTC',
+    currencySymbol: null,
+    type: 'crypto',
+    rateUsd: '104232.50',
+  },
+  {
+    id: 'ethereum',
+    symbol: 'ETH',
+    currencySymbol: null,
+    type: 'crypto',
+    rateUsd: '3210.45',
+  },
+];
+
+const mockRate = {
+  id: 'euro',
+  symbol: 'EUR',
+  currencySymbol: '€',
+  type: 'fiat',
+  rateUsd: '0.9182',
+};
+
+describe('handleGetRates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all rates when no slug is provided', async () => {
+    mockGetRates.mockResolvedValueOnce(mockRates);
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Currency Conversion Rates');
+    expect(result.content[0].text).toContain('Fiat');
+    expect(result.content[0].text).toContain('EUR');
+    expect(result.content[0].text).toContain('BTC');
+  });
+
+  it('should return a single rate when slug is provided', async () => {
+    mockGetRate.mockResolvedValueOnce(mockRate);
+
+    const result = await handleGetRates({ slug: 'euro' });
+    expect(result.content[0].text).toContain('Rate: Euro');
+    expect(result.content[0].text).toContain('EUR');
+    expect(result.content[0].text).toContain('0.9182');
+  });
+
+  it('should return error message when rates data is null', async () => {
+    mockGetRates.mockResolvedValueOnce(null);
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Failed to retrieve');
+  });
+
+  it('should return not-found message when single rate is null', async () => {
+    mockGetRate.mockResolvedValueOnce(null);
+
+    const result = await handleGetRates({ slug: 'unknown-currency' });
+    expect(result.content[0].text).toContain('Could not find rate for slug');
+  });
+
+  it('should handle fiat and crypto rates separately', async () => {
+    mockGetRates.mockResolvedValueOnce(mockRates);
+
+    const result = await handleGetRates({});
+    const text = result.content[0].text;
+    expect(text).toContain('Fiat');
+    expect(text).toContain('Crypto');
+  });
+
+  it('should return error message on exception', async () => {
+    mockGetRates.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetRates({});
+    expect(result.content[0].text).toContain('Network failure');
+  });
+});

--- a/src/tools/__tests__/technical-analysis.test.ts
+++ b/src/tools/__tests__/technical-analysis.test.ts
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../services/coincap.js', () => ({
+  searchAsset: jest.fn(),
+  getAssets: jest.fn(),
+  getMarkets: jest.fn(),
+  getHistoricalData: jest.fn(),
+  getTechnicalAnalysis: jest.fn(),
+  clearCache: jest.fn(),
+}));
+
+const { searchAsset, getTechnicalAnalysis } =
+  await import('../../services/coincap.js');
+const { handleGetTechnicalAnalysis } = await import('../technical-analysis.js');
+
+const mockSearchAsset = searchAsset as jest.MockedFunction<typeof searchAsset>;
+const mockGetTechnicalAnalysis = getTechnicalAnalysis as jest.MockedFunction<
+  typeof getTechnicalAnalysis
+>;
+
+const mockAsset = {
+  id: 'bitcoin',
+  rank: '1',
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  priceUsd: '104232.50',
+  changePercent24Hr: '2.50',
+  volumeUsd24Hr: '30000000000',
+  marketCapUsd: '2050000000000',
+  supply: '19000000',
+  maxSupply: '21000000',
+  vwap24Hr: '103890.00',
+};
+
+const mockTa = {
+  sma: { period: 20, value: '102100.00' },
+  ema: { period: 20, value: '103450.00' },
+  rsi: { period: 14, value: '58.30' },
+  macd: { value: '1234.50', signal: '980.20', histogram: '254.30' },
+  vwap: { value: '103890.00' },
+};
+
+describe('handleGetTechnicalAnalysis', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return formatted technical analysis for a valid symbol', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce(mockTa);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain(
+      'Technical Analysis: Bitcoin (BTC)'
+    );
+    expect(result.content[0].text).toContain('SMA');
+    expect(result.content[0].text).toContain('EMA');
+    expect(result.content[0].text).toContain('RSI');
+    expect(result.content[0].text).toContain('MACD');
+    expect(result.content[0].text).toContain('VWAP');
+  });
+
+  it('should return not-found message for unknown symbol', async () => {
+    mockSearchAsset.mockResolvedValueOnce(null);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'ZZZZZ' });
+    expect(result.content[0].text).toContain(
+      'Could not find cryptocurrency with symbol ZZZZZ'
+    );
+  });
+
+  it('should return error message when technical analysis data is null', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce(null);
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain(
+      'Failed to retrieve technical analysis'
+    );
+  });
+
+  it('should handle partial indicator data gracefully', async () => {
+    mockSearchAsset.mockResolvedValueOnce(mockAsset);
+    mockGetTechnicalAnalysis.mockResolvedValueOnce({
+      sma: null,
+      ema: null,
+      rsi: { period: 14, value: '58.30' },
+      macd: null,
+      vwap: null,
+    });
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('RSI');
+    expect(result.content[0].text).toContain('N/A');
+  });
+
+  it('should return error message on exception', async () => {
+    mockSearchAsset.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handleGetTechnicalAnalysis({ symbol: 'BTC' });
+    expect(result.content[0].text).toContain('Network failure');
+  });
+
+  it('should throw on missing symbol', async () => {
+    await expect(handleGetTechnicalAnalysis({})).rejects.toThrow();
+  });
+});

--- a/src/tools/__tests__/top-assets.test.ts
+++ b/src/tools/__tests__/top-assets.test.ts
@@ -15,16 +15,30 @@ const mockGetAssets = getAssets as jest.MockedFunction<typeof getAssets>;
 
 const mockAssets = [
   {
-    id: 'bitcoin', rank: '1', symbol: 'BTC', name: 'Bitcoin',
-    priceUsd: '50000.00', changePercent24Hr: '2.50',
-    volumeUsd24Hr: '30000000000', marketCapUsd: '950000000000',
-    supply: '19000000', maxSupply: '21000000', vwap24Hr: '49500.00',
+    id: 'bitcoin',
+    rank: '1',
+    symbol: 'BTC',
+    name: 'Bitcoin',
+    priceUsd: '50000.00',
+    changePercent24Hr: '2.50',
+    volumeUsd24Hr: '30000000000',
+    marketCapUsd: '950000000000',
+    supply: '19000000',
+    maxSupply: '21000000',
+    vwap24Hr: '49500.00',
   },
   {
-    id: 'ethereum', rank: '2', symbol: 'ETH', name: 'Ethereum',
-    priceUsd: '3000.00', changePercent24Hr: '1.20',
-    volumeUsd24Hr: '15000000000', marketCapUsd: '350000000000',
-    supply: '120000000', maxSupply: null, vwap24Hr: '2950.00',
+    id: 'ethereum',
+    rank: '2',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    priceUsd: '3000.00',
+    changePercent24Hr: '1.20',
+    volumeUsd24Hr: '15000000000',
+    marketCapUsd: '350000000000',
+    supply: '120000000',
+    maxSupply: null,
+    vwap24Hr: '2950.00',
   },
 ];
 
@@ -37,7 +51,9 @@ describe('handleGetTopAssets', () => {
     mockGetAssets.mockResolvedValueOnce({ data: mockAssets });
 
     const result = await handleGetTopAssets({});
-    expect(result.content[0].text).toContain('Top Cryptocurrencies by Market Cap');
+    expect(result.content[0].text).toContain(
+      'Top Cryptocurrencies by Market Cap'
+    );
     expect(result.content[0].text).toContain('Bitcoin (BTC)');
     expect(result.content[0].text).toContain('Ethereum (ETH)');
   });

--- a/src/tools/exchanges.ts
+++ b/src/tools/exchanges.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { getExchanges, getExchange } from '../services/coincap.js';
+import { formatExchanges, formatExchange } from '../services/formatters.js';
+
+export const GetExchangesSchema = z.object({
+  exchangeId: z
+    .string()
+    .optional()
+    .describe(
+      "Optional: specific exchange ID to look up (e.g. 'binance', 'coinbase', 'kraken')"
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(10)
+    .optional()
+    .describe(
+      'Number of top exchanges to return when listing (1-50, default 10)'
+    ),
+});
+
+export async function handleGetExchanges(args: unknown) {
+  const { exchangeId, limit = 10 } = GetExchangesSchema.parse(args);
+
+  try {
+    if (exchangeId) {
+      const exchange = await getExchange(exchangeId);
+
+      if (!exchange) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Could not find exchange "${exchangeId}". Try an ID like 'binance', 'coinbase', or 'kraken'.`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: formatExchange(exchange) }],
+      };
+    }
+
+    const exchanges = await getExchanges(limit);
+
+    if (!exchanges) {
+      return {
+        content: [{ type: 'text', text: 'Failed to retrieve exchanges' }],
+      };
+    }
+
+    return {
+      content: [
+        { type: 'text', text: formatExchanges(exchanges.slice(0, limit)) },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve exchanges: ${String(error)}`,
+        },
+      ],
+    };
+  }
+}

--- a/src/tools/historical.ts
+++ b/src/tools/historical.ts
@@ -3,9 +3,22 @@ import { searchAsset, getHistoricalData } from '../services/coincap.js';
 import { formatHistoricalAnalysis } from '../services/formatters.js';
 
 export const GetHistoricalAnalysisSchema = z.object({
-  symbol: z.string().min(1).describe("Cryptocurrency symbol or name (e.g. BTC or Bitcoin)"),
-  interval: z.enum(['m1', 'm5', 'm15', 'm30', 'h1', 'h2', 'h6', 'h12', 'd1']).default('h1').describe("Data interval: m1=1min, m5=5min, m15=15min, m30=30min, h1=1hr, h2=2hr, h6=6hr, h12=12hr, d1=daily"),
-  days: z.number().min(1).max(30).default(7).describe("Number of days of historical data to retrieve (1-30)"),
+  symbol: z
+    .string()
+    .min(1)
+    .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
+  interval: z
+    .enum(['m1', 'm5', 'm15', 'm30', 'h1', 'h2', 'h6', 'h12', 'd1'])
+    .default('h1')
+    .describe(
+      'Data interval: m1=1min, m5=5min, m15=15min, m30=30min, h1=1hr, h2=2hr, h6=6hr, h12=12hr, d1=daily'
+    ),
+  days: z
+    .number()
+    .min(1)
+    .max(30)
+    .default(7)
+    .describe('Number of days of historical data to retrieve (1-30)'),
 });
 
 export async function handleGetHistoricalAnalysis(args: unknown) {
@@ -17,7 +30,12 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
 
     if (!asset) {
       return {
-        content: [{ type: "text", text: `Could not find cryptocurrency with symbol ${upperSymbol}` }],
+        content: [
+          {
+            type: 'text',
+            text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
+          },
+        ],
       };
     }
 
@@ -25,30 +43,45 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
     // across calls made within the same 60-second TTL window
     const now = Date.now();
     const end = now - (now % 60000);
-    const start = end - (days * 24 * 60 * 60 * 1000);
+    const start = end - days * 24 * 60 * 60 * 1000;
     const historyData = await getHistoricalData(asset.id, interval, start, end);
 
     if (!historyData) {
       return {
-        content: [{ type: "text", text: "Failed to retrieve historical data" }],
+        content: [{ type: 'text', text: 'Failed to retrieve historical data' }],
       };
     }
 
     if (!historyData.data.length) {
       return {
-        content: [{ type: "text", text: "No historical data available for the selected time period" }],
+        content: [
+          {
+            type: 'text',
+            text: 'No historical data available for the selected time period',
+          },
+        ],
       };
     }
 
     return {
-      content: [{ type: "text", text: formatHistoricalAnalysis(asset, historyData.data) }],
+      content: [
+        {
+          type: 'text',
+          text: formatHistoricalAnalysis(asset, historyData.data),
+        },
+      ],
     };
   } catch (error) {
     return {
-      content: [{ 
-        type: "text", 
-        text: error instanceof Error ? error.message : `Failed to retrieve historical data: ${String(error)}` 
-      }],
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve historical data: ${String(error)}`,
+        },
+      ],
     };
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,3 +2,6 @@ export * from './price.js';
 export * from './market.js';
 export * from './historical.js';
 export * from './top-assets.js';
+export * from './technical-analysis.js';
+export * from './rates.js';
+export * from './exchanges.js';

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -3,7 +3,10 @@ import { searchAsset, getMarkets } from '../services/coincap.js';
 import { formatMarketAnalysis } from '../services/formatters.js';
 
 export const GetMarketAnalysisSchema = z.object({
-  symbol: z.string().min(1).describe("Cryptocurrency symbol or name (e.g. BTC or Bitcoin)"),
+  symbol: z
+    .string()
+    .min(1)
+    .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
 export async function handleGetMarketAnalysis(args: unknown) {
@@ -15,7 +18,12 @@ export async function handleGetMarketAnalysis(args: unknown) {
 
     if (!asset) {
       return {
-        content: [{ type: "text", text: `Could not find cryptocurrency with symbol ${upperSymbol}` }],
+        content: [
+          {
+            type: 'text',
+            text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
+          },
+        ],
       };
     }
 
@@ -23,19 +31,26 @@ export async function handleGetMarketAnalysis(args: unknown) {
 
     if (!marketsData) {
       return {
-        content: [{ type: "text", text: "Failed to retrieve market data" }],
+        content: [{ type: 'text', text: 'Failed to retrieve market data' }],
       };
     }
 
     return {
-      content: [{ type: "text", text: formatMarketAnalysis(asset, marketsData.data) }],
+      content: [
+        { type: 'text', text: formatMarketAnalysis(asset, marketsData.data) },
+      ],
     };
   } catch (error) {
     return {
-      content: [{
-        type: "text",
-        text: error instanceof Error ? error.message : `Failed to retrieve data: ${String(error)}`
-      }],
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve data: ${String(error)}`,
+        },
+      ],
     };
   }
 }

--- a/src/tools/price.ts
+++ b/src/tools/price.ts
@@ -3,7 +3,10 @@ import { searchAsset } from '../services/coincap.js';
 import { formatPriceInfo } from '../services/formatters.js';
 
 export const GetPriceArgumentsSchema = z.object({
-  symbol: z.string().min(1).describe("Cryptocurrency symbol or name (e.g. BTC or Bitcoin)"),
+  symbol: z
+    .string()
+    .min(1)
+    .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
 export async function handleGetPrice(args: unknown) {
@@ -15,19 +18,29 @@ export async function handleGetPrice(args: unknown) {
 
     if (!asset) {
       return {
-        content: [{ type: "text", text: `Could not find cryptocurrency with symbol ${upperSymbol}` }],
+        content: [
+          {
+            type: 'text',
+            text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
+          },
+        ],
       };
     }
 
     return {
-      content: [{ type: "text", text: formatPriceInfo(asset) }],
+      content: [{ type: 'text', text: formatPriceInfo(asset) }],
     };
   } catch (error) {
     return {
-      content: [{
-        type: "text",
-        text: error instanceof Error ? error.message : `Failed to retrieve cryptocurrency data: ${String(error)}`
-      }],
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve cryptocurrency data: ${String(error)}`,
+        },
+      ],
     };
   }
 }

--- a/src/tools/rates.ts
+++ b/src/tools/rates.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { getRates, getRate } from '../services/coincap.js';
+import { formatRates, formatRate } from '../services/formatters.js';
+
+export const GetRatesSchema = z.object({
+  slug: z
+    .string()
+    .optional()
+    .describe(
+      "Optional: rate slug to fetch a single rate (e.g. 'us-dollar', 'euro', 'bitcoin')"
+    ),
+});
+
+export async function handleGetRates(args: unknown) {
+  const { slug } = GetRatesSchema.parse(args);
+
+  try {
+    if (slug) {
+      const rate = await getRate(slug);
+
+      if (!rate) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Could not find rate for slug "${slug}". Try a slug like 'us-dollar', 'euro', or 'bitcoin'.`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: formatRate(rate) }],
+      };
+    }
+
+    const rates = await getRates();
+
+    if (!rates) {
+      return {
+        content: [{ type: 'text', text: 'Failed to retrieve currency rates' }],
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: formatRates(rates) }],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve rates: ${String(error)}`,
+        },
+      ],
+    };
+  }
+}

--- a/src/tools/technical-analysis.ts
+++ b/src/tools/technical-analysis.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { searchAsset, getTechnicalAnalysis } from '../services/coincap.js';
+import { formatTechnicalAnalysis } from '../services/formatters.js';
+
+export const GetTechnicalAnalysisSchema = z.object({
+  symbol: z
+    .string()
+    .min(1)
+    .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
+});
+
+export async function handleGetTechnicalAnalysis(args: unknown) {
+  const { symbol } = GetTechnicalAnalysisSchema.parse(args);
+  const upperSymbol = symbol.toUpperCase();
+
+  try {
+    const asset = await searchAsset(upperSymbol);
+
+    if (!asset) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
+          },
+        ],
+      };
+    }
+
+    const ta = await getTechnicalAnalysis(asset.id);
+
+    if (!ta) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Failed to retrieve technical analysis for ${asset.name} (${asset.symbol})`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: formatTechnicalAnalysis(asset, ta) }],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve technical analysis: ${String(error)}`,
+        },
+      ],
+    };
+  }
+}

--- a/src/tools/top-assets.ts
+++ b/src/tools/top-assets.ts
@@ -3,7 +3,12 @@ import { getAssets } from '../services/coincap.js';
 import { formatTopAssets } from '../services/formatters.js';
 
 export const GetTopAssetsSchema = z.object({
-  limit: z.number().min(1).max(50).default(10).describe("Number of top assets to return, ranked by market cap (1-50)"),
+  limit: z
+    .number()
+    .min(1)
+    .max(50)
+    .default(10)
+    .describe('Number of top assets to return, ranked by market cap (1-50)'),
 });
 
 export async function handleGetTopAssets(args: unknown) {
@@ -14,7 +19,7 @@ export async function handleGetTopAssets(args: unknown) {
 
     if (!assetsData) {
       return {
-        content: [{ type: "text", text: "Failed to retrieve assets data" }],
+        content: [{ type: 'text', text: 'Failed to retrieve assets data' }],
       };
     }
 
@@ -22,19 +27,24 @@ export async function handleGetTopAssets(args: unknown) {
 
     if (!topAssets.length) {
       return {
-        content: [{ type: "text", text: "No assets data available" }],
+        content: [{ type: 'text', text: 'No assets data available' }],
       };
     }
 
     return {
-      content: [{ type: "text", text: formatTopAssets(topAssets) }],
+      content: [{ type: 'text', text: formatTopAssets(topAssets) }],
     };
   } catch (error) {
     return {
-      content: [{
-        type: "text",
-        text: error instanceof Error ? error.message : `Failed to retrieve assets data: ${String(error)}`
-      }],
+      content: [
+        {
+          type: 'text',
+          text:
+            error instanceof Error
+              ? error.message
+              : `Failed to retrieve assets data: ${String(error)}`,
+        },
+      ],
     };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,3 +40,71 @@ export interface Market {
 export interface MarketsResponse {
   data: Market[];
 }
+
+export interface TechnicalAnalysisIndicatorSMA {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorEMA {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorRSI {
+  period: number;
+  value: string;
+}
+
+export interface TechnicalAnalysisIndicatorMACD {
+  value: string;
+  signal: string;
+  histogram: string;
+}
+
+export interface TechnicalAnalysisIndicatorVWAP {
+  value: string;
+}
+
+export interface TechnicalAnalysis {
+  sma: TechnicalAnalysisIndicatorSMA | null;
+  ema: TechnicalAnalysisIndicatorEMA | null;
+  rsi: TechnicalAnalysisIndicatorRSI | null;
+  macd: TechnicalAnalysisIndicatorMACD | null;
+  vwap: TechnicalAnalysisIndicatorVWAP | null;
+}
+
+export interface Rate {
+  id: string;
+  symbol: string;
+  currencySymbol: string | null;
+  type: string;
+  rateUsd: string;
+}
+
+export interface RatesResponse {
+  data: Rate[];
+}
+
+export interface RateResponse {
+  data: Rate;
+}
+
+export interface Exchange {
+  exchangeId: string;
+  name: string;
+  rank: string;
+  percentTotalVolume: string | null;
+  volumeUsd: string | null;
+  tradingPairs: string | null;
+  socket: boolean | null;
+  updated: number;
+}
+
+export interface ExchangesResponse {
+  data: Exchange[];
+}
+
+export interface ExchangeResponse {
+  data: Exchange;
+}


### PR DESCRIPTION
## Summary

Adds three new MCP tools using previously unused CoinCap v3 API endpoints, plus full code quality tooling (Prettier, ESLint, TypeScript type-check).

### New MCP Tools

| Tool | Endpoint | Description |
|------|----------|-------------|
| `get-technical-analysis` | `/ta/{id}/allLatest` | SMA, EMA, RSI (with Overbought/Oversold/Neutral), MACD (with Bullish/Bearish), VWAP |
| `get-rates` | `/rates`, `/rates/{slug}` | USD-based fiat and crypto conversion rates; optional slug for single rate |
| `get-exchanges` | `/exchanges`, `/exchanges/{id}` | Top exchanges by 24h volume; optional exchangeId and limit |

### Code Quality Tooling

- **Prettier** — `.prettierrc` config (`singleQuote`, `semi`, `trailingComma: es5`, `tabWidth: 2`), `.prettierignore`, `npm run format`
- **ESLint** — `typescript-eslint` rules, `eslint.config.js`, `npm run lint` / `npm run lint:fix`
- **TypeScript** — `npm run types:check` (`tsc --noEmit`), zero errors
- **`.gitignore`** — updated to track `.prettierrc` and `.prettierignore`
- All 24 source files reformatted; existing files untouched in behavior

### Tests

- 51 tests passing across 9 suites (up from 31 tests / 6 suites)
- 6 new tests for `get-technical-analysis`
- 6 new tests for `get-rates`
- 8 new tests for `get-exchanges`

### Docs

- `CLAUDE.md` — updated tool table (4 → 7 tools), added tooling section with all new scripts
- `README.md` — added development scripts section, documented 3 new tools, added sample prompts

## Replaces

Closes #159 (feat/technical-analysis)
Closes #160 (feat/currency-rates)
Closes #161 (feat/exchanges)

This single PR replaces those three to produce one semantic-release version bump.

## Test plan

- [ ] `npm run format` — all source files formatted, no changes
- [ ] `npm run lint` — zero warnings or errors
- [ ] `npm run types:check` — zero TypeScript errors
- [ ] `npm test` — 51 tests pass across 9 suites
- [ ] `npm run build` — TypeScript compiles without errors
- [ ] Verify all 7 tools appear in `npm run inspector`