### PR TITLE
feat: add outputSchema and dot-notation tool names for Smithery AI scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,23 +62,25 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 - **`src/services/formatters.ts`** — pure formatting functions for tool output text.
 - **`src/types/index.ts`** — shared TypeScript interfaces for CoinCap API responses.
 
-### Thirteen registered MCP tools (kebab-case naming)
+### Thirteen registered MCP tools (dot-notation naming)
+
+Tools are organized into four categories: `price.*`, `market.*`, `assets.*`, `analysis.*`. All tools declare `outputSchema` and return `structuredContent` alongside formatted text.
 
 | Tool | Handler | API endpoint |
 |------|---------|--------------|
-| `get-crypto-price` | `handleGetPrice` | `/assets` |
-| `get-market-analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
-| `get-historical-analysis` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
-| `get-top-assets` | `handleGetTopAssets` | `/assets` |
-| `get-technical-analysis` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
-| `get-rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
-| `get-exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
-| `search-assets` | `handleSearchAssets` | `/assets?search={query}` |
-| `get-global-metrics` | `handleGetGlobalMetrics` | `/assets` (aggregated) |
-| `compare-crypto` | `handleCompareCrypto` | `/assets` (multiple lookups) |
-| `get-candlestick-data` | `handleGetCandlestickData` | `/assets/{id}/candles` |
-| `get-price-conversion` | `handleGetPriceConversion` | `/assets` + `/rates` |
-| `get-asset-info` | `handleGetAssetInfo` | `/assets` (single lookup) |
+| `price.get` | `handleGetPrice` | `/assets` |
+| `price.convert` | `handleGetPriceConversion` | `/assets` + `/rates` |
+| `market.analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
+| `market.global` | `handleGetGlobalMetrics` | `/assets` (aggregated) |
+| `market.rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
+| `market.exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
+| `assets.top` | `handleGetTopAssets` | `/assets` |
+| `assets.search` | `handleSearchAssets` | `/assets?search={query}` |
+| `assets.info` | `handleGetAssetInfo` | `/assets` (single lookup) |
+| `assets.compare` | `handleCompareCrypto` | `/assets` (multiple lookups) |
+| `analysis.historical` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
+| `analysis.technical` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
+| `analysis.candlestick` | `handleGetCandlestickData` | `/assets/{id}/candles` |
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A Model Context Protocol (MCP) server that provides comprehensive cryptocurrency
 - **BREAKING**: CoinCap v2 API removed. Now uses v3 API exclusively. A `COINCAP_API_KEY` is required (free tier available at [pro.coincap.io/dashboard](https://pro.coincap.io/dashboard))
 - Streamable HTTP transport added (while keeping STDIO compatibility)
 - Smithery CLI scripts to build and run the HTTP server
-- **6 new tools**: `search-assets`, `get-global-metrics`, `compare-crypto`, `get-candlestick-data`, `get-price-conversion`, `get-asset-info`
+- **6 new tools**: `assets.search`, `market.global`, `assets.compare`, `analysis.candlestick`, `price.convert`, `assets.info`
+- **Dot-notation tool naming**: All tools organized into a navigable tree (`price.*`, `market.*`, `assets.*`, `analysis.*`)
+- **Output schemas**: All tools now declare `outputSchema` with `structuredContent` for type-safe responses
 - **MCP best practices**: `isError` flag on validation errors, server description, and `asset://{symbol}` resource template
 
 ## Usage
@@ -134,7 +136,7 @@ Launch Claude Desktop to start using the crypto analysis tools.
 
 ## Tools
 
-#### get-crypto-price
+#### price.get
 
 Gets current price and 24h stats for any cryptocurrency, including:
 - Current price in USD
@@ -143,7 +145,14 @@ Gets current price and 24h stats for any cryptocurrency, including:
 - Market cap
 - Market rank
 
-#### get-market-analysis
+#### price.convert
+
+Converts a cryptocurrency amount into any fiat currency:
+- Uses real-time price data and USD-based exchange rates
+- Parameters: `symbol` (e.g. `BTC`), `amount` (default 1), `currency` (default `usd`)
+- Example: 2.5 BTC in EUR
+
+#### market.analysis
 
 Provides detailed market analysis including:
 - Top 5 exchanges by volume
@@ -151,55 +160,7 @@ Provides detailed market analysis including:
 - Volume distribution analysis
 - VWAP (Volume Weighted Average Price)
 
-#### get-historical-analysis
-
-Analyzes historical price data with:
-- Customizable time intervals (5min to 1 day)
-- Support for up to 30 days of historical data
-- Price trend analysis
-- Volatility metrics
-- High/low price ranges
-
-#### get-top-assets
-
-Lists top cryptocurrencies ranked by market cap, including:
-- Current price in USD
-- 24-hour price change
-- Market cap and rank
-- Configurable result count (1–50, default 10)
-
-#### get-technical-analysis
-
-Returns the latest technical indicators for any cryptocurrency:
-- SMA (Simple Moving Average) with period
-- EMA (Exponential Moving Average) with period
-- RSI (Relative Strength Index) with Overbought/Oversold/Neutral signal
-- MACD with signal line, histogram, and Bullish/Bearish label
-- VWAP (Volume Weighted Average Price, 24h)
-
-#### get-rates
-
-Returns USD-based conversion rates for fiat currencies and cryptocurrencies:
-- All fiat currency rates (USD base)
-- Top 10 cryptocurrency rates
-- Optional `slug` parameter (e.g. `euro`, `bitcoin`) for a single rate lookup
-
-#### get-exchanges
-
-Lists top cryptocurrency exchanges ranked by 24h volume:
-- Exchange name, rank, and 24h volume in USD
-- Number of trading pairs and market share percentage
-- Optional `exchangeId` parameter (e.g. `binance`) for single exchange details
-- Optional `limit` parameter (1–50, default 10)
-
-#### search-assets
-
-Searches for cryptocurrencies by name or symbol with fuzzy matching:
-- Returns matching assets with symbol, name, price, and rank
-- Configurable result count (1–50, default 10)
-- Example: search "bit" returns Bitcoin, Bitcoin Cash, BitTorrent, etc.
-
-#### get-global-metrics
+#### market.global
 
 Provides an overview of the entire cryptocurrency market:
 - Total market capitalization across all assets
@@ -208,34 +169,75 @@ Provides an overview of the entire cryptocurrency market:
 - Bitcoin dominance percentage
 - Top gainers and losers
 
-#### compare-crypto
+#### market.rates
 
-Compares 2–5 cryptocurrencies side by side:
-- Price, 24h change, market cap, volume, and rank for each asset
-- Comma-separated symbols (e.g. `BTC,ETH,SOL`)
-- Highlights best performer by 24h change
+Returns USD-based conversion rates for fiat currencies and cryptocurrencies:
+- All fiat currency rates (USD base)
+- Top 10 cryptocurrency rates
+- Optional `slug` parameter (e.g. `euro`, `bitcoin`) for a single rate lookup
 
-#### get-candlestick-data
+#### market.exchanges
 
-Retrieves OHLCV candlestick data from a specific exchange:
-- Open, high, low, close, and volume for each candle
-- Configurable exchange (e.g. `binance`), quote currency (e.g. `usd`), and interval (`5m`, `15m`, `1h`, `6h`, `1d`)
-- Supports 1–30 days of historical candles
+Lists top cryptocurrency exchanges ranked by 24h volume:
+- Exchange name, rank, and 24h volume in USD
+- Number of trading pairs and market share percentage
+- Optional `exchangeId` parameter (e.g. `binance`) for single exchange details
+- Optional `limit` parameter (1–50, default 10)
 
-#### get-price-conversion
+#### assets.top
 
-Converts a cryptocurrency amount into any fiat currency:
-- Uses real-time price data and USD-based exchange rates
-- Parameters: `symbol` (e.g. `BTC`), `amount` (default 1), `currency` (default `usd`)
-- Example: 2.5 BTC in EUR
+Lists top cryptocurrencies ranked by market cap, including:
+- Current price in USD
+- 24-hour price change
+- Market cap and rank
+- Configurable result count (1–50, default 10)
 
-#### get-asset-info
+#### assets.search
+
+Searches for cryptocurrencies by name or symbol with fuzzy matching:
+- Returns matching assets with symbol, name, price, and rank
+- Configurable result count (1–50, default 10)
+- Example: search "bit" returns Bitcoin, Bitcoin Cash, BitTorrent, etc.
+
+#### assets.info
 
 Returns detailed metadata for a single cryptocurrency:
 - ID, rank, symbol, and name
 - Price, 24h change, market cap, and volume
 - Circulating supply and max supply
 - VWAP (24h)
+
+#### assets.compare
+
+Compares 2–5 cryptocurrencies side by side:
+- Price, 24h change, market cap, volume, and rank for each asset
+- Comma-separated symbols (e.g. `BTC,ETH,SOL`)
+- Highlights best performer by 24h change
+
+#### analysis.historical
+
+Analyzes historical price data with:
+- Customizable time intervals (5min to 1 day)
+- Support for up to 30 days of historical data
+- Price trend analysis
+- Volatility metrics
+- High/low price ranges
+
+#### analysis.technical
+
+Returns the latest technical indicators for any cryptocurrency:
+- SMA (Simple Moving Average) with period
+- EMA (Exponential Moving Average) with period
+- RSI (Relative Strength Index) with Overbought/Oversold/Neutral signal
+- MACD with signal line, histogram, and Bullish/Bearish label
+- VWAP (Volume Weighted Average Price, 24h)
+
+#### analysis.candlestick
+
+Retrieves OHLCV candlestick data from a specific exchange:
+- Open, high, low, close, and volume for each candle
+- Configurable exchange (e.g. `binance`), quote currency (e.g. `usd`), and interval (`5m`, `15m`, `1h`, `6h`, `1d`)
+- Supports 1–30 days of historical candles
 
 ## Resources
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -54,7 +54,7 @@ const serverCard = {
   },
   tools: [
     {
-      name: 'get-crypto-price',
+      name: 'price.get',
       description: 'Get current price and 24h stats for a cryptocurrency',
       inputSchema: {
         type: 'object',
@@ -66,6 +66,27 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          symbol: { type: 'string' },
+          priceUsd: { type: 'string' },
+          changePercent24Hr: { type: ['string', 'null'] },
+          volumeUsd24Hr: { type: ['string', 'null'] },
+          marketCapUsd: { type: ['string', 'null'] },
+          rank: { type: ['string', 'null'] },
+        },
+        required: [
+          'name',
+          'symbol',
+          'priceUsd',
+          'changePercent24Hr',
+          'volumeUsd24Hr',
+          'marketCapUsd',
+          'rank',
+        ],
+      },
       annotations: {
         title: 'Get Crypto Price',
         readOnlyHint: true,
@@ -75,7 +96,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-market-analysis',
+      name: 'market.analysis',
       description:
         'Get detailed market analysis including top exchanges and volume distribution',
       inputSchema: {
@@ -88,6 +109,42 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          symbol: { type: 'string' },
+          priceUsd: { type: 'string' },
+          volumeUsd24Hr: { type: ['string', 'null'] },
+          vwap24Hr: { type: ['string', 'null'] },
+          topMarkets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                exchangeId: { type: 'string' },
+                priceUsd: { type: 'string' },
+                volumeUsd24Hr: { type: 'string' },
+                volumePercent: { type: 'string' },
+              },
+              required: [
+                'exchangeId',
+                'priceUsd',
+                'volumeUsd24Hr',
+                'volumePercent',
+              ],
+            },
+          },
+        },
+        required: [
+          'name',
+          'symbol',
+          'priceUsd',
+          'volumeUsd24Hr',
+          'vwap24Hr',
+          'topMarkets',
+        ],
+      },
       annotations: {
         title: 'Get Market Analysis',
         readOnlyHint: true,
@@ -97,7 +154,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-historical-analysis',
+      name: 'analysis.historical',
       description: 'Get historical price analysis with customizable timeframe',
       inputSchema: {
         type: 'object',
@@ -123,6 +180,31 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          symbol: { type: 'string' },
+          periodHigh: { type: 'number' },
+          periodLow: { type: 'number' },
+          priceChangePercent: { type: 'string' },
+          currentPrice: { type: 'number' },
+          startingPrice: { type: 'number' },
+          priceRange: { type: 'number' },
+          rangePercentage: { type: 'string' },
+        },
+        required: [
+          'name',
+          'symbol',
+          'periodHigh',
+          'periodLow',
+          'priceChangePercent',
+          'currentPrice',
+          'startingPrice',
+          'priceRange',
+          'rangePercentage',
+        ],
+      },
       annotations: {
         title: 'Get Historical Analysis',
         readOnlyHint: true,
@@ -132,7 +214,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-top-assets',
+      name: 'assets.top',
       description: 'Get top cryptocurrencies ranked by market cap',
       inputSchema: {
         type: 'object',
@@ -147,6 +229,36 @@ const serverCard = {
           },
         },
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          assets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                rank: { type: ['string', 'null'] },
+                symbol: { type: 'string' },
+                name: { type: 'string' },
+                priceUsd: { type: 'string' },
+                changePercent24Hr: { type: ['string', 'null'] },
+                marketCapUsd: { type: ['string', 'null'] },
+              },
+              required: [
+                'id',
+                'rank',
+                'symbol',
+                'name',
+                'priceUsd',
+                'changePercent24Hr',
+                'marketCapUsd',
+              ],
+            },
+          },
+        },
+        required: ['assets'],
+      },
       annotations: {
         title: 'Get Top Assets',
         readOnlyHint: true,
@@ -156,7 +268,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-technical-analysis',
+      name: 'analysis.technical',
       description:
         'Get the latest technical indicators for a cryptocurrency including SMA, EMA, RSI, MACD, and VWAP',
       inputSchema: {
@@ -169,6 +281,61 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          symbol: { type: 'string' },
+          currentPrice: { type: 'string' },
+          sma: {
+            type: ['object', 'null'],
+            properties: {
+              period: { type: 'number' },
+              value: { type: 'string' },
+            },
+          },
+          ema: {
+            type: ['object', 'null'],
+            properties: {
+              period: { type: 'number' },
+              value: { type: 'string' },
+            },
+          },
+          rsi: {
+            type: ['object', 'null'],
+            properties: {
+              period: { type: 'number' },
+              value: { type: 'string' },
+              signal: { type: 'string' },
+            },
+          },
+          macd: {
+            type: ['object', 'null'],
+            properties: {
+              value: { type: 'string' },
+              signal: { type: 'string' },
+              histogram: { type: 'string' },
+              signalLabel: { type: 'string' },
+            },
+          },
+          vwap: {
+            type: ['object', 'null'],
+            properties: {
+              value: { type: 'string' },
+            },
+          },
+        },
+        required: [
+          'name',
+          'symbol',
+          'currentPrice',
+          'sma',
+          'ema',
+          'rsi',
+          'macd',
+          'vwap',
+        ],
+      },
       annotations: {
         title: 'Get Technical Analysis',
         readOnlyHint: true,
@@ -178,7 +345,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-rates',
+      name: 'market.rates',
       description:
         "Get USD-based conversion rates for fiat currencies and cryptocurrencies. Optionally pass a slug (e.g. 'euro', 'us-dollar', 'bitcoin') to look up a single rate.",
       inputSchema: {
@@ -191,6 +358,26 @@ const serverCard = {
           },
         },
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          rates: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                symbol: { type: 'string' },
+                currencySymbol: { type: ['string', 'null'] },
+                type: { type: 'string' },
+                rateUsd: { type: 'string' },
+              },
+              required: ['id', 'symbol', 'currencySymbol', 'type', 'rateUsd'],
+            },
+          },
+        },
+        required: ['rates'],
+      },
       annotations: {
         title: 'Get Currency Rates',
         readOnlyHint: true,
@@ -200,7 +387,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-exchanges',
+      name: 'market.exchanges',
       description:
         "Get top cryptocurrency exchanges ranked by 24h volume. Optionally pass an exchangeId (e.g. 'binance', 'coinbase') to get details for a specific exchange.",
       inputSchema: {
@@ -221,6 +408,36 @@ const serverCard = {
           },
         },
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          exchanges: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                exchangeId: { type: 'string' },
+                name: { type: 'string' },
+                rank: { type: 'string' },
+                percentTotalVolume: { type: ['string', 'null'] },
+                volumeUsd: { type: ['string', 'null'] },
+                tradingPairs: { type: ['string', 'null'] },
+                socket: { type: ['boolean', 'null'] },
+              },
+              required: [
+                'exchangeId',
+                'name',
+                'rank',
+                'percentTotalVolume',
+                'volumeUsd',
+                'tradingPairs',
+                'socket',
+              ],
+            },
+          },
+        },
+        required: ['exchanges'],
+      },
       annotations: {
         title: 'Get Exchanges',
         readOnlyHint: true,
@@ -230,7 +447,7 @@ const serverCard = {
       },
     },
     {
-      name: 'search-assets',
+      name: 'assets.search',
       description:
         'Search for cryptocurrencies by name, symbol, or partial match. Returns multiple matching assets with their ID, name, symbol, rank, and current price.',
       inputSchema: {
@@ -252,6 +469,26 @@ const serverCard = {
         },
         required: ['query'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          results: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                rank: { type: ['string', 'null'] },
+                symbol: { type: 'string' },
+                name: { type: 'string' },
+                priceUsd: { type: 'string' },
+              },
+              required: ['id', 'rank', 'symbol', 'name', 'priceUsd'],
+            },
+          },
+        },
+        required: ['results'],
+      },
       annotations: {
         title: 'Search Crypto Assets',
         readOnlyHint: true,
@@ -261,11 +498,26 @@ const serverCard = {
       },
     },
     {
-      name: 'get-global-metrics',
+      name: 'market.global',
       description:
         'Get a global overview of the cryptocurrency market including total market capitalization, 24-hour trading volume, Bitcoin dominance percentage, and the number of active cryptocurrencies.',
       inputSchema: {
         type: 'object',
+      },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          totalMarketCap: { type: 'number' },
+          totalVolume: { type: 'number' },
+          btcDominance: { type: 'string' },
+          activeCryptocurrencies: { type: 'number' },
+        },
+        required: [
+          'totalMarketCap',
+          'totalVolume',
+          'btcDominance',
+          'activeCryptocurrencies',
+        ],
       },
       annotations: {
         title: 'Get Global Metrics',
@@ -276,7 +528,7 @@ const serverCard = {
       },
     },
     {
-      name: 'compare-crypto',
+      name: 'assets.compare',
       description:
         'Compare 2-5 cryptocurrencies side-by-side including price, 24h change, volume, market cap, and rank. Pass symbols as a comma-separated list (e.g. "BTC,ETH,SOL").',
       inputSchema: {
@@ -290,6 +542,40 @@ const serverCard = {
         },
         required: ['symbols'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          assets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                symbol: { type: 'string' },
+                priceUsd: { type: 'string' },
+                changePercent24Hr: { type: ['string', 'null'] },
+                volumeUsd24Hr: { type: ['string', 'null'] },
+                marketCapUsd: { type: ['string', 'null'] },
+                rank: { type: ['string', 'null'] },
+              },
+              required: [
+                'name',
+                'symbol',
+                'priceUsd',
+                'changePercent24Hr',
+                'volumeUsd24Hr',
+                'marketCapUsd',
+                'rank',
+              ],
+            },
+          },
+          notFound: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        required: ['assets', 'notFound'],
+      },
       annotations: {
         title: 'Compare Cryptocurrencies',
         readOnlyHint: true,
@@ -299,7 +585,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-candlestick-data',
+      name: 'analysis.candlestick',
       description:
         'Get OHLCV candlestick data for a cryptocurrency from a specific exchange. Useful for charting and technical analysis.',
       inputSchema: {
@@ -338,6 +624,30 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          symbol: { type: 'string' },
+          exchange: { type: 'string' },
+          candles: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                open: { type: 'string' },
+                high: { type: 'string' },
+                low: { type: 'string' },
+                close: { type: 'string' },
+                volume: { type: 'string' },
+                period: { type: 'number' },
+              },
+              required: ['open', 'high', 'low', 'close', 'volume', 'period'],
+            },
+          },
+        },
+        required: ['name', 'symbol', 'exchange', 'candles'],
+      },
       annotations: {
         title: 'Get Candlestick Data',
         readOnlyHint: true,
@@ -347,7 +657,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-price-conversion',
+      name: 'price.convert',
       description:
         'Convert a cryptocurrency amount to any fiat currency (e.g. USD, EUR, JPY). Uses real-time exchange rates for accurate conversions.',
       inputSchema: {
@@ -374,6 +684,23 @@ const serverCard = {
         },
         required: ['symbol'],
       },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          fromSymbol: { type: 'string' },
+          amount: { type: 'number' },
+          toCurrency: { type: 'string' },
+          conversionRate: { type: 'number' },
+          convertedAmount: { type: 'number' },
+        },
+        required: [
+          'fromSymbol',
+          'amount',
+          'toCurrency',
+          'conversionRate',
+          'convertedAmount',
+        ],
+      },
       annotations: {
         title: 'Get Price Conversion',
         readOnlyHint: true,
@@ -383,7 +710,7 @@ const serverCard = {
       },
     },
     {
-      name: 'get-asset-info',
+      name: 'assets.info',
       description:
         'Get detailed metadata for a cryptocurrency including ID, rank, supply, max supply, VWAP, market cap, and 24h volume.',
       inputSchema: {
@@ -395,6 +722,35 @@ const serverCard = {
           },
         },
         required: ['symbol'],
+      },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          rank: { type: ['string', 'null'] },
+          symbol: { type: 'string' },
+          name: { type: 'string' },
+          priceUsd: { type: 'string' },
+          changePercent24Hr: { type: ['string', 'null'] },
+          marketCapUsd: { type: ['string', 'null'] },
+          volumeUsd24Hr: { type: ['string', 'null'] },
+          supply: { type: ['string', 'null'] },
+          maxSupply: { type: ['string', 'null'] },
+          vwap24Hr: { type: ['string', 'null'] },
+        },
+        required: [
+          'id',
+          'rank',
+          'symbol',
+          'name',
+          'priceUsd',
+          'changePercent24Hr',
+          'marketCapUsd',
+          'volumeUsd24Hr',
+          'supply',
+          'maxSupply',
+          'vwap24Hr',
+        ],
       },
       annotations: {
         title: 'Get Asset Info',

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,19 @@ import {
   GetCandlestickDataSchema,
   GetPriceConversionSchema,
   GetAssetInfoSchema,
+  PriceOutputSchema,
+  MarketAnalysisOutputSchema,
+  HistoricalAnalysisOutputSchema,
+  TopAssetsOutputSchema,
+  TechnicalAnalysisOutputSchema,
+  RatesOutputSchema,
+  ExchangesOutputSchema,
+  SearchAssetsOutputSchema,
+  GlobalMetricsOutputSchema,
+  CompareOutputSchema,
+  CandlestickOutputSchema,
+  PriceConversionOutputSchema,
+  AssetInfoOutputSchema,
 } from './tools/index.js';
 
 export const configSchema = z.object({
@@ -83,12 +96,13 @@ export function createServer({
   });
 
   server.registerTool(
-    'get-crypto-price',
+    'price.get',
     {
       title: 'Get Crypto Price',
       description:
         'Get real-time price, 24-hour change percentage, trading volume, and market cap for any cryptocurrency by symbol or name.',
       inputSchema: GetPriceArgumentsSchema.shape,
+      outputSchema: PriceOutputSchema.shape,
       annotations: {
         title: 'Get Crypto Price',
         readOnlyHint: true,
@@ -104,12 +118,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-market-analysis',
+    'market.analysis',
     {
       title: 'Get Market Analysis',
       description:
         'Get detailed market analysis for a cryptocurrency including the top 5 exchanges by volume, price per exchange, and volume distribution percentages.',
       inputSchema: GetMarketAnalysisSchema.shape,
+      outputSchema: MarketAnalysisOutputSchema.shape,
       annotations: {
         title: 'Get Market Analysis',
         readOnlyHint: true,
@@ -125,12 +140,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-historical-analysis',
+    'analysis.historical',
     {
       title: 'Get Historical Analysis',
       description:
         'Get historical price data for a cryptocurrency with trend analysis including period high/low, price change percentage, and volatility metrics over a customizable timeframe.',
       inputSchema: GetHistoricalAnalysisSchema.shape,
+      outputSchema: HistoricalAnalysisOutputSchema.shape,
       annotations: {
         title: 'Get Historical Analysis',
         readOnlyHint: true,
@@ -146,12 +162,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-top-assets',
+    'assets.top',
     {
       title: 'Get Top Assets',
       description:
         'Get the top cryptocurrencies ranked by market cap, with real-time price, 24-hour change percentage, and market cap for each asset.',
       inputSchema: GetTopAssetsSchema.shape,
+      outputSchema: TopAssetsOutputSchema.shape,
       annotations: {
         title: 'Get Top Assets',
         readOnlyHint: true,
@@ -167,12 +184,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-technical-analysis',
+    'analysis.technical',
     {
       title: 'Get Technical Analysis',
       description:
         'Get the latest technical indicators for a cryptocurrency including SMA, EMA, RSI, MACD, and VWAP to assess momentum, trend direction, and overbought/oversold conditions.',
       inputSchema: GetTechnicalAnalysisSchema.shape,
+      outputSchema: TechnicalAnalysisOutputSchema.shape,
       annotations: {
         title: 'Get Technical Analysis',
         readOnlyHint: true,
@@ -188,12 +206,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-rates',
+    'market.rates',
     {
       title: 'Get Currency Rates',
       description:
         "Get USD-based conversion rates for fiat currencies and cryptocurrencies. Optionally pass a slug (e.g. 'euro', 'us-dollar', 'bitcoin') to look up a single rate.",
       inputSchema: GetRatesSchema.shape,
+      outputSchema: RatesOutputSchema.shape,
       annotations: {
         title: 'Get Currency Rates',
         readOnlyHint: true,
@@ -209,12 +228,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-exchanges',
+    'market.exchanges',
     {
       title: 'Get Exchanges',
       description:
         "Get top cryptocurrency exchanges ranked by 24h volume. Optionally pass an exchangeId (e.g. 'binance', 'coinbase') to get details for a specific exchange including volume, trading pairs, and market share.",
       inputSchema: GetExchangesSchema.shape,
+      outputSchema: ExchangesOutputSchema.shape,
       annotations: {
         title: 'Get Exchanges',
         readOnlyHint: true,
@@ -230,12 +250,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'search-assets',
+    'assets.search',
     {
       title: 'Search Crypto Assets',
       description:
         'Search for cryptocurrencies by name, symbol, or partial match. Returns multiple matching assets with their ID, name, symbol, rank, and current price.',
       inputSchema: SearchAssetsSchema.shape,
+      outputSchema: SearchAssetsOutputSchema.shape,
       annotations: {
         title: 'Search Crypto Assets',
         readOnlyHint: true,
@@ -251,12 +272,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-global-metrics',
+    'market.global',
     {
       title: 'Get Global Metrics',
       description:
         'Get a global overview of the cryptocurrency market including total market capitalization, 24-hour trading volume, Bitcoin dominance percentage, and the number of active cryptocurrencies.',
       inputSchema: GetGlobalMetricsSchema.shape,
+      outputSchema: GlobalMetricsOutputSchema.shape,
       annotations: {
         title: 'Get Global Metrics',
         readOnlyHint: true,
@@ -272,12 +294,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'compare-crypto',
+    'assets.compare',
     {
       title: 'Compare Cryptocurrencies',
       description:
         'Compare 2-5 cryptocurrencies side-by-side including price, 24h change, volume, market cap, and rank. Pass symbols as a comma-separated list (e.g. "BTC,ETH,SOL").',
       inputSchema: CompareCryptoSchema.shape,
+      outputSchema: CompareOutputSchema.shape,
       annotations: {
         title: 'Compare Cryptocurrencies',
         readOnlyHint: true,
@@ -293,12 +316,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-candlestick-data',
+    'analysis.candlestick',
     {
       title: 'Get Candlestick Data',
       description:
         'Get OHLCV candlestick data for a cryptocurrency from a specific exchange. Useful for charting and technical analysis.',
       inputSchema: GetCandlestickDataSchema.shape,
+      outputSchema: CandlestickOutputSchema.shape,
       annotations: {
         title: 'Get Candlestick Data',
         readOnlyHint: true,
@@ -314,12 +338,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-price-conversion',
+    'price.convert',
     {
       title: 'Get Price Conversion',
       description:
         'Convert a cryptocurrency amount to any fiat currency (e.g. USD, EUR, JPY). Uses real-time exchange rates for accurate conversions.',
       inputSchema: GetPriceConversionSchema.shape,
+      outputSchema: PriceConversionOutputSchema.shape,
       annotations: {
         title: 'Get Price Conversion',
         readOnlyHint: true,
@@ -335,12 +360,13 @@ export function createServer({
   );
 
   server.registerTool(
-    'get-asset-info',
+    'assets.info',
     {
       title: 'Get Asset Info',
       description:
         'Get detailed metadata for a cryptocurrency including ID, rank, supply, max supply, VWAP, market cap, and 24h volume.',
       inputSchema: GetAssetInfoSchema.shape,
+      outputSchema: AssetInfoOutputSchema.shape,
       annotations: {
         title: 'Get Asset Info',
         readOnlyHint: true,

--- a/src/tools/asset-info.ts
+++ b/src/tools/asset-info.ts
@@ -9,6 +9,20 @@ export const GetAssetInfoSchema = z.object({
     .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
+export const AssetInfoOutputSchema = z.object({
+  id: z.string(),
+  rank: z.string().nullable(),
+  symbol: z.string(),
+  name: z.string(),
+  priceUsd: z.string(),
+  changePercent24Hr: z.string().nullable(),
+  marketCapUsd: z.string().nullable(),
+  volumeUsd24Hr: z.string().nullable(),
+  supply: z.string().nullable(),
+  maxSupply: z.string().nullable(),
+  vwap24Hr: z.string().nullable(),
+});
+
 export async function handleGetAssetInfo(args: unknown) {
   try {
     const { symbol } = GetAssetInfoSchema.parse(args);
@@ -29,6 +43,19 @@ export async function handleGetAssetInfo(args: unknown) {
 
     return {
       content: [{ type: 'text', text: formatAssetInfo(asset) }],
+      structuredContent: {
+        id: asset.id,
+        rank: asset.rank,
+        symbol: asset.symbol,
+        name: asset.name,
+        priceUsd: asset.priceUsd,
+        changePercent24Hr: asset.changePercent24Hr,
+        marketCapUsd: asset.marketCapUsd,
+        volumeUsd24Hr: asset.volumeUsd24Hr,
+        supply: asset.supply,
+        maxSupply: asset.maxSupply,
+        vwap24Hr: asset.vwap24Hr,
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/candlestick.ts
+++ b/src/tools/candlestick.ts
@@ -29,6 +29,22 @@ export const GetCandlestickDataSchema = z.object({
     .describe('Number of days of candlestick data to retrieve (1-30)'),
 });
 
+export const CandlestickOutputSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  exchange: z.string(),
+  candles: z.array(
+    z.object({
+      open: z.string(),
+      high: z.string(),
+      low: z.string(),
+      close: z.string(),
+      volume: z.string(),
+      period: z.number(),
+    })
+  ),
+});
+
 export async function handleGetCandlestickData(args: unknown) {
   try {
     const { symbol, exchange, quote, interval, days } =
@@ -85,6 +101,19 @@ export async function handleGetCandlestickData(args: unknown) {
           text: formatCandlestickData(asset, candlesData.data, exchange),
         },
       ],
+      structuredContent: {
+        name: asset.name,
+        symbol: asset.symbol,
+        exchange,
+        candles: candlesData.data.map((c) => ({
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+          volume: c.volume,
+          period: c.period,
+        })),
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/compare.ts
+++ b/src/tools/compare.ts
@@ -12,6 +12,21 @@ export const CompareCryptoSchema = z.object({
     ),
 });
 
+export const CompareOutputSchema = z.object({
+  assets: z.array(
+    z.object({
+      name: z.string(),
+      symbol: z.string(),
+      priceUsd: z.string(),
+      changePercent24Hr: z.string().nullable(),
+      volumeUsd24Hr: z.string().nullable(),
+      marketCapUsd: z.string().nullable(),
+      rank: z.string().nullable(),
+    })
+  ),
+  notFound: z.array(z.string()),
+});
+
 export async function handleCompareCrypto(args: unknown) {
   try {
     const { symbols } = CompareCryptoSchema.parse(args);
@@ -61,6 +76,18 @@ export async function handleCompareCrypto(args: unknown) {
 
     return {
       content: [{ type: 'text', text: output }],
+      structuredContent: {
+        assets: results.map((a) => ({
+          name: a.name,
+          symbol: a.symbol,
+          priceUsd: a.priceUsd,
+          changePercent24Hr: a.changePercent24Hr,
+          volumeUsd24Hr: a.volumeUsd24Hr,
+          marketCapUsd: a.marketCapUsd,
+          rank: a.rank,
+        })),
+        notFound,
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/exchanges.ts
+++ b/src/tools/exchanges.ts
@@ -21,6 +21,20 @@ export const GetExchangesSchema = z.object({
     ),
 });
 
+export const ExchangesOutputSchema = z.object({
+  exchanges: z.array(
+    z.object({
+      exchangeId: z.string(),
+      name: z.string(),
+      rank: z.string(),
+      percentTotalVolume: z.string().nullable(),
+      volumeUsd: z.string().nullable(),
+      tradingPairs: z.string().nullable(),
+      socket: z.boolean().nullable(),
+    })
+  ),
+});
+
 export async function handleGetExchanges(args: unknown) {
   const { exchangeId, limit = 10 } = GetExchangesSchema.parse(args);
 
@@ -41,6 +55,19 @@ export async function handleGetExchanges(args: unknown) {
 
       return {
         content: [{ type: 'text', text: formatExchange(exchange) }],
+        structuredContent: {
+          exchanges: [
+            {
+              exchangeId: exchange.exchangeId,
+              name: exchange.name,
+              rank: exchange.rank,
+              percentTotalVolume: exchange.percentTotalVolume,
+              volumeUsd: exchange.volumeUsd,
+              tradingPairs: exchange.tradingPairs,
+              socket: exchange.socket,
+            },
+          ],
+        },
       };
     }
 
@@ -56,6 +83,17 @@ export async function handleGetExchanges(args: unknown) {
       content: [
         { type: 'text', text: formatExchanges(exchanges.slice(0, limit)) },
       ],
+      structuredContent: {
+        exchanges: exchanges.slice(0, limit).map((ex) => ({
+          exchangeId: ex.exchangeId,
+          name: ex.name,
+          rank: ex.rank,
+          percentTotalVolume: ex.percentTotalVolume,
+          volumeUsd: ex.volumeUsd,
+          tradingPairs: ex.tradingPairs,
+          socket: ex.socket,
+        })),
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/global-metrics.ts
+++ b/src/tools/global-metrics.ts
@@ -4,6 +4,13 @@ import { formatGlobalMetrics } from '../services/formatters.js';
 
 export const GetGlobalMetricsSchema = z.object({});
 
+export const GlobalMetricsOutputSchema = z.object({
+  totalMarketCap: z.number(),
+  totalVolume: z.number(),
+  btcDominance: z.string(),
+  activeCryptocurrencies: z.number(),
+});
+
 export async function handleGetGlobalMetrics(args: unknown) {
   try {
     GetGlobalMetricsSchema.parse(args);
@@ -24,8 +31,31 @@ export async function handleGetGlobalMetrics(args: unknown) {
       };
     }
 
+    const totalMarketCap = assetsData.data.reduce(
+      (sum, a) => sum + parseFloat(a.marketCapUsd || '0'),
+      0
+    );
+    const totalVolume = assetsData.data.reduce(
+      (sum, a) => sum + parseFloat(a.volumeUsd24Hr || '0'),
+      0
+    );
+    const btc = assetsData.data.find((a) => a.symbol.toUpperCase() === 'BTC');
+    const btcDominance =
+      btc && totalMarketCap > 0
+        ? (
+            (parseFloat(btc.marketCapUsd || '0') / totalMarketCap) *
+            100
+          ).toFixed(2)
+        : 'N/A';
+
     return {
       content: [{ type: 'text', text: formatGlobalMetrics(assetsData.data) }],
+      structuredContent: {
+        totalMarketCap,
+        totalVolume,
+        btcDominance,
+        activeCryptocurrencies: assetsData.data.length,
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/historical.ts
+++ b/src/tools/historical.ts
@@ -21,6 +21,18 @@ export const GetHistoricalAnalysisSchema = z.object({
     .describe('Number of days of historical data to retrieve (1-30)'),
 });
 
+export const HistoricalAnalysisOutputSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  periodHigh: z.number(),
+  periodLow: z.number(),
+  priceChangePercent: z.string(),
+  currentPrice: z.number(),
+  startingPrice: z.number(),
+  priceRange: z.number(),
+  rangePercentage: z.string(),
+});
+
 export async function handleGetHistoricalAnalysis(args: unknown) {
   const { symbol, interval, days } = GetHistoricalAnalysisSchema.parse(args);
   const upperSymbol = symbol.toUpperCase();
@@ -63,6 +75,19 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
       };
     }
 
+    const currentPrice = parseFloat(asset.priceUsd);
+    const oldestPrice = parseFloat(historyData.data[0].priceUsd);
+    const highestPrice = Math.max(
+      ...historyData.data.map((h) => parseFloat(h.priceUsd))
+    );
+    const lowestPrice = Math.min(
+      ...historyData.data.map((h) => parseFloat(h.priceUsd))
+    );
+    const priceChange = (
+      ((currentPrice - oldestPrice) / oldestPrice) *
+      100
+    ).toFixed(2);
+
     return {
       content: [
         {
@@ -70,6 +95,20 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
           text: formatHistoricalAnalysis(asset, historyData.data),
         },
       ],
+      structuredContent: {
+        name: asset.name,
+        symbol: asset.symbol,
+        periodHigh: highestPrice,
+        periodLow: lowestPrice,
+        priceChangePercent: priceChange,
+        currentPrice,
+        startingPrice: oldestPrice,
+        priceRange: highestPrice - lowestPrice,
+        rangePercentage: (
+          ((highestPrice - lowestPrice) / lowestPrice) *
+          100
+        ).toFixed(2),
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -9,6 +9,22 @@ export const GetMarketAnalysisSchema = z.object({
     .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
+export const MarketAnalysisOutputSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  priceUsd: z.string(),
+  volumeUsd24Hr: z.string().nullable(),
+  vwap24Hr: z.string().nullable(),
+  topMarkets: z.array(
+    z.object({
+      exchangeId: z.string(),
+      priceUsd: z.string(),
+      volumeUsd24Hr: z.string(),
+      volumePercent: z.string(),
+    })
+  ),
+});
+
 export async function handleGetMarketAnalysis(args: unknown) {
   const { symbol } = GetMarketAnalysisSchema.parse(args);
   const upperSymbol = symbol.toUpperCase();
@@ -35,10 +51,35 @@ export async function handleGetMarketAnalysis(args: unknown) {
       };
     }
 
+    const totalVolume = marketsData.data.reduce(
+      (sum, market) => sum + parseFloat(market.volumeUsd24Hr),
+      0
+    );
+    const topMarkets = marketsData.data
+      .sort((a, b) => parseFloat(b.volumeUsd24Hr) - parseFloat(a.volumeUsd24Hr))
+      .slice(0, 5)
+      .map((market) => ({
+        exchangeId: market.exchangeId,
+        priceUsd: market.priceUsd,
+        volumeUsd24Hr: market.volumeUsd24Hr,
+        volumePercent: (
+          (parseFloat(market.volumeUsd24Hr) / totalVolume) *
+          100
+        ).toFixed(2),
+      }));
+
     return {
       content: [
         { type: 'text', text: formatMarketAnalysis(asset, marketsData.data) },
       ],
+      structuredContent: {
+        name: asset.name,
+        symbol: asset.symbol,
+        priceUsd: asset.priceUsd,
+        volumeUsd24Hr: asset.volumeUsd24Hr,
+        vwap24Hr: asset.vwap24Hr,
+        topMarkets,
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/price-conversion.ts
+++ b/src/tools/price-conversion.ts
@@ -19,6 +19,14 @@ export const GetPriceConversionSchema = z.object({
     .describe('Target currency code (e.g. "usd", "eur", "gbp", "jpy")'),
 });
 
+export const PriceConversionOutputSchema = z.object({
+  fromSymbol: z.string(),
+  amount: z.number(),
+  toCurrency: z.string(),
+  conversionRate: z.number(),
+  convertedAmount: z.number(),
+});
+
 export async function handleGetPriceConversion(args: unknown) {
   try {
     const { symbol, amount, currency } = GetPriceConversionSchema.parse(args);
@@ -75,6 +83,13 @@ export async function handleGetPriceConversion(args: unknown) {
           ),
         },
       ],
+      structuredContent: {
+        fromSymbol: upperSymbol,
+        amount,
+        toCurrency: upperCurrency,
+        conversionRate,
+        convertedAmount: amount * conversionRate,
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/price.ts
+++ b/src/tools/price.ts
@@ -9,6 +9,16 @@ export const GetPriceArgumentsSchema = z.object({
     .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
+export const PriceOutputSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  priceUsd: z.string(),
+  changePercent24Hr: z.string().nullable(),
+  volumeUsd24Hr: z.string().nullable(),
+  marketCapUsd: z.string().nullable(),
+  rank: z.string().nullable(),
+});
+
 export async function handleGetPrice(args: unknown) {
   const { symbol } = GetPriceArgumentsSchema.parse(args);
   const upperSymbol = symbol.toUpperCase();
@@ -29,6 +39,15 @@ export async function handleGetPrice(args: unknown) {
 
     return {
       content: [{ type: 'text', text: formatPriceInfo(asset) }],
+      structuredContent: {
+        name: asset.name,
+        symbol: asset.symbol,
+        priceUsd: asset.priceUsd,
+        changePercent24Hr: asset.changePercent24Hr,
+        volumeUsd24Hr: asset.volumeUsd24Hr,
+        marketCapUsd: asset.marketCapUsd,
+        rank: asset.rank,
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/rates.ts
+++ b/src/tools/rates.ts
@@ -11,6 +11,18 @@ export const GetRatesSchema = z.object({
     ),
 });
 
+export const RatesOutputSchema = z.object({
+  rates: z.array(
+    z.object({
+      id: z.string(),
+      symbol: z.string(),
+      currencySymbol: z.string().nullable(),
+      type: z.string(),
+      rateUsd: z.string(),
+    })
+  ),
+});
+
 export async function handleGetRates(args: unknown) {
   const { slug } = GetRatesSchema.parse(args);
 
@@ -31,6 +43,17 @@ export async function handleGetRates(args: unknown) {
 
       return {
         content: [{ type: 'text', text: formatRate(rate) }],
+        structuredContent: {
+          rates: [
+            {
+              id: rate.id,
+              symbol: rate.symbol,
+              currencySymbol: rate.currencySymbol,
+              type: rate.type,
+              rateUsd: rate.rateUsd,
+            },
+          ],
+        },
       };
     }
 
@@ -44,6 +67,15 @@ export async function handleGetRates(args: unknown) {
 
     return {
       content: [{ type: 'text', text: formatRates(rates) }],
+      structuredContent: {
+        rates: rates.map((r) => ({
+          id: r.id,
+          symbol: r.symbol,
+          currencySymbol: r.currencySymbol,
+          type: r.type,
+          rateUsd: r.rateUsd,
+        })),
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/search-assets.ts
+++ b/src/tools/search-assets.ts
@@ -18,6 +18,18 @@ export const SearchAssetsSchema = z.object({
     .describe('Maximum number of results to return (1-50, default 10)'),
 });
 
+export const SearchAssetsOutputSchema = z.object({
+  results: z.array(
+    z.object({
+      id: z.string(),
+      rank: z.string().nullable(),
+      symbol: z.string(),
+      name: z.string(),
+      priceUsd: z.string(),
+    })
+  ),
+});
+
 export async function handleSearchAssets(args: unknown) {
   try {
     const { query, limit } = SearchAssetsSchema.parse(args);
@@ -43,6 +55,15 @@ export async function handleSearchAssets(args: unknown) {
 
     return {
       content: [{ type: 'text', text: formatSearchResults(results) }],
+      structuredContent: {
+        results: results.map((a) => ({
+          id: a.id,
+          rank: a.rank,
+          symbol: a.symbol,
+          name: a.name,
+          priceUsd: a.priceUsd,
+        })),
+      },
     };
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/tools/technical-analysis.ts
+++ b/src/tools/technical-analysis.ts
@@ -9,6 +9,26 @@ export const GetTechnicalAnalysisSchema = z.object({
     .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
 });
 
+export const TechnicalAnalysisOutputSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  currentPrice: z.string(),
+  sma: z.object({ period: z.number(), value: z.string() }).nullable(),
+  ema: z.object({ period: z.number(), value: z.string() }).nullable(),
+  rsi: z
+    .object({ period: z.number(), value: z.string(), signal: z.string() })
+    .nullable(),
+  macd: z
+    .object({
+      value: z.string(),
+      signal: z.string(),
+      histogram: z.string(),
+      signalLabel: z.string(),
+    })
+    .nullable(),
+  vwap: z.object({ value: z.string() }).nullable(),
+});
+
 export async function handleGetTechnicalAnalysis(args: unknown) {
   const { symbol } = GetTechnicalAnalysisSchema.parse(args);
   const upperSymbol = symbol.toUpperCase();
@@ -40,8 +60,49 @@ export async function handleGetTechnicalAnalysis(args: unknown) {
       };
     }
 
+    const rsiValue = ta.rsi ? parseFloat(ta.rsi.value) : null;
+    const rsiSignal =
+      rsiValue === null
+        ? 'N/A'
+        : rsiValue > 70
+          ? 'Overbought'
+          : rsiValue < 30
+            ? 'Oversold'
+            : 'Neutral';
+
+    const macdHistogram = ta.macd ? parseFloat(ta.macd.histogram) : null;
+    const macdSignalLabel =
+      macdHistogram === null
+        ? 'N/A'
+        : macdHistogram > 0
+          ? 'Bullish'
+          : 'Bearish';
+
     return {
       content: [{ type: 'text', text: formatTechnicalAnalysis(asset, ta) }],
+      structuredContent: {
+        name: asset.name,
+        symbol: asset.symbol,
+        currentPrice: asset.priceUsd,
+        sma: ta.sma ? { period: ta.sma.period, value: ta.sma.value } : null,
+        ema: ta.ema ? { period: ta.ema.period, value: ta.ema.value } : null,
+        rsi: ta.rsi
+          ? {
+              period: ta.rsi.period,
+              value: ta.rsi.value,
+              signal: rsiSignal,
+            }
+          : null,
+        macd: ta.macd
+          ? {
+              value: ta.macd.value,
+              signal: ta.macd.signal,
+              histogram: ta.macd.histogram,
+              signalLabel: macdSignalLabel,
+            }
+          : null,
+        vwap: ta.vwap ? { value: ta.vwap.value } : null,
+      },
     };
   } catch (error) {
     return {

--- a/src/tools/top-assets.ts
+++ b/src/tools/top-assets.ts
@@ -11,6 +11,20 @@ export const GetTopAssetsSchema = z.object({
     .describe('Number of top assets to return, ranked by market cap (1-50)'),
 });
 
+export const TopAssetsOutputSchema = z.object({
+  assets: z.array(
+    z.object({
+      id: z.string(),
+      rank: z.string().nullable(),
+      symbol: z.string(),
+      name: z.string(),
+      priceUsd: z.string(),
+      changePercent24Hr: z.string().nullable(),
+      marketCapUsd: z.string().nullable(),
+    })
+  ),
+});
+
 export async function handleGetTopAssets(args: unknown) {
   const { limit } = GetTopAssetsSchema.parse(args);
 
@@ -33,6 +47,17 @@ export async function handleGetTopAssets(args: unknown) {
 
     return {
       content: [{ type: 'text', text: formatTopAssets(topAssets) }],
+      structuredContent: {
+        assets: topAssets.map((a) => ({
+          id: a.id,
+          rank: a.rank,
+          symbol: a.symbol,
+          name: a.name,
+          priceUsd: a.priceUsd,
+          changePercent24Hr: a.changePercent24Hr,
+          marketCapUsd: a.marketCapUsd,
+        })),
+      },
     };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

Enhance Smithery AI scoring by achieving perfect scores for **output schemas** and **naming** criteria.

### Changes

- **Output schemas**: Added Zod `outputSchema` definitions and `structuredContent` returns to all 13 tool handlers. Each tool now returns both human-readable text (`content`) and machine-parseable structured data (`structuredContent`).
- **Dot-notation tool naming**: Renamed all 13 tools from flat kebab-case to a navigable dot-notation tree with 4 categories:

| Old Name | New Name |
|----------|----------|
| `get-crypto-price` | `price.get` |
| `get-price-conversion` | `price.convert` |
| `get-market-analysis` | `market.analysis` |
| `get-global-metrics` | `market.global` |
| `get-rates` | `market.rates` |
| `get-exchanges` | `market.exchanges` |
| `get-top-assets` | `assets.top` |
| `search-assets` | `assets.search` |
| `get-asset-info` | `assets.info` |
| `compare-crypto` | `assets.compare` |
| `get-historical-analysis` | `analysis.historical` |
| `get-technical-analysis` | `analysis.technical` |
| `get-candlestick-data` | `analysis.candlestick` |

- **Server card**: Updated `src/http.ts` with new tool names and `outputSchema` JSON Schema definitions for all 13 tools.
- **Documentation**: Updated `README.md` and `CLAUDE.md` with new tool names and architecture details.

### Verification

Per [SEP-986](https://modelcontextprotocol.io/seps/986-specify-format-for-tool-names) (Final, Standards Track), dots are explicitly allowed in tool names. Claude's `mcp__<server>__<tool>` routing pattern uses `__` delimiters, so dots in tool names don't interfere.

- ✅ Build passes (`pnpm build`)
- ✅ Lint passes (`pnpm lint`)
- ✅ All 89 tests pass across 15 test files (`pnpm test`)

### Breaking Change

Tool names changed from kebab-case to dot-notation. Clients referencing tools by name will need to use the new names.