### PR TITLE
chore: optimize CI workflows to eliminate duplicate runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
       - main
-      - master
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read # for checkout
@@ -38,9 +41,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Test
-        run: pnpm test 
-      
       - name: Configure Git identity
         run: |
           git config user.name "${{ github.actor }}"


### PR DESCRIPTION
## Summary

Optimizes CI workflows to reduce redundant runs and speed up pipeline execution.

### Changes

- **Add custom CodeQL workflow** (`.github/workflows/codeql.yml`): Triggers only on `push` to `main` (not `pull_request`), which overrides GitHub's dynamic CodeQL that was running on both events — eliminating the duplicate CodeQL run on every PR merge. Also includes a weekly scheduled scan.
- **Add concurrency control to `node.js.yml`**: Cancels in-progress runs when a new commit is pushed to the same branch/PR, avoiding wasted CI minutes.
- **Remove redundant `pnpm test` from `release.yml`**: Tests already run via `node.js.yml` on push to `main`, so running them again in release is duplicate work.
- **Remove `master` branch trigger from `release.yml`**: Only `main` is used; `master` doesn't exist.
- **Add concurrency control to `release.yml`**: Queues releases (no cancel) to prevent race conditions.

### Before vs After (on PR merge to main)

| Workflow | Before | After |
|----------|--------|-------|
| CodeQL | 2 runs (PR + push) | 1 run (push only) |
| Build and Test | 2 runs (PR + push, no cancel) | 2 runs (PR + push, stale cancelled) |
| Release | 1 run (with redundant test) | 1 run (no redundant test) |
| **Total** | **5 runs** | **4 runs** (fewer on rapid pushes) |

### Notes

The custom CodeQL workflow overrides GitHub's dynamic `github-code-scanning/codeql` workflow. Once merged, the dynamic workflow should no longer appear in the actions runs list.