### PR TITLE
fix: revert dot-notation to hyphen-based tool names for MCP spec compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,25 +62,25 @@ MCP client → transport (stdio or HTTP) → src/index.ts (createServer)
 - **`src/services/formatters.ts`** — pure formatting functions for tool output text.
 - **`src/types/index.ts`** — shared TypeScript interfaces for CoinCap API responses.
 
-### Thirteen registered MCP tools (dot-notation naming)
+### Thirteen registered MCP tools (category-prefixed naming)
 
-Tools are organized into four categories: `price.*`, `market.*`, `assets.*`, `analysis.*`. All tools declare `outputSchema` and return `structuredContent` alongside formatted text.
+Tools are organized into four categories: `price-*`, `market-*`, `assets-*`, `analysis-*`. All tools declare `outputSchema` and return `structuredContent` alongside formatted text.
 
 | Tool | Handler | API endpoint |
 |------|---------|--------------|
-| `price.get` | `handleGetPrice` | `/assets` |
-| `price.convert` | `handleGetPriceConversion` | `/assets` + `/rates` |
-| `market.analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
-| `market.global` | `handleGetGlobalMetrics` | `/assets` (aggregated) |
-| `market.rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
-| `market.exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
-| `assets.top` | `handleGetTopAssets` | `/assets` |
-| `assets.search` | `handleSearchAssets` | `/assets?search={query}` |
-| `assets.info` | `handleGetAssetInfo` | `/assets` (single lookup) |
-| `assets.compare` | `handleCompareCrypto` | `/assets` (multiple lookups) |
-| `analysis.historical` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
-| `analysis.technical` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
-| `analysis.candlestick` | `handleGetCandlestickData` | `/assets/{id}/candles` |
+| `price-get` | `handleGetPrice` | `/assets` |
+| `price-convert` | `handleGetPriceConversion` | `/assets` + `/rates` |
+| `market-analysis` | `handleGetMarketAnalysis` | `/assets/{id}/markets` |
+| `market-global` | `handleGetGlobalMetrics` | `/assets` (aggregated) |
+| `market-rates` | `handleGetRates` | `/rates` and `/rates/{slug}` |
+| `market-exchanges` | `handleGetExchanges` | `/exchanges` and `/exchanges/{id}` |
+| `assets-top` | `handleGetTopAssets` | `/assets` |
+| `assets-search` | `handleSearchAssets` | `/assets?search={query}` |
+| `assets-info` | `handleGetAssetInfo` | `/assets` (single lookup) |
+| `assets-compare` | `handleCompareCrypto` | `/assets` (multiple lookups) |
+| `analysis-historical` | `handleGetHistoricalAnalysis` | `/assets/{id}/history` |
+| `analysis-technical` | `handleGetTechnicalAnalysis` | `/ta/{id}/allLatest` |
+| `analysis-candlestick` | `handleGetCandlestickData` | `/assets/{id}/candles` |
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A Model Context Protocol (MCP) server that provides comprehensive cryptocurrency
 - **BREAKING**: CoinCap v2 API removed. Now uses v3 API exclusively. A `COINCAP_API_KEY` is required (free tier available at [pro.coincap.io/dashboard](https://pro.coincap.io/dashboard))
 - Streamable HTTP transport added (while keeping STDIO compatibility)
 - Smithery CLI scripts to build and run the HTTP server
-- **6 new tools**: `assets.search`, `market.global`, `assets.compare`, `analysis.candlestick`, `price.convert`, `assets.info`
-- **Dot-notation tool naming**: All tools organized into a navigable tree (`price.*`, `market.*`, `assets.*`, `analysis.*`)
+- **6 new tools**: `assets-search`, `market-global`, `assets-compare`, `analysis-candlestick`, `price-convert`, `assets-info`
+- **Hierarchical tool naming**: All tools organized into category-prefixed names (`price-*`, `market-*`, `assets-*`, `analysis-*`)
 - **Output schemas**: All tools now declare `outputSchema` with `structuredContent` for type-safe responses
 - **MCP best practices**: `isError` flag on validation errors, server description, and `asset://{symbol}` resource template
 
@@ -136,7 +136,7 @@ Launch Claude Desktop to start using the crypto analysis tools.
 
 ## Tools
 
-#### price.get
+#### price-get
 
 Gets current price and 24h stats for any cryptocurrency, including:
 - Current price in USD
@@ -145,14 +145,14 @@ Gets current price and 24h stats for any cryptocurrency, including:
 - Market cap
 - Market rank
 
-#### price.convert
+#### price-convert
 
 Converts a cryptocurrency amount into any fiat currency:
 - Uses real-time price data and USD-based exchange rates
 - Parameters: `symbol` (e.g. `BTC`), `amount` (default 1), `currency` (default `usd`)
 - Example: 2.5 BTC in EUR
 
-#### market.analysis
+#### market-analysis
 
 Provides detailed market analysis including:
 - Top 5 exchanges by volume
@@ -160,7 +160,7 @@ Provides detailed market analysis including:
 - Volume distribution analysis
 - VWAP (Volume Weighted Average Price)
 
-#### market.global
+#### market-global
 
 Provides an overview of the entire cryptocurrency market:
 - Total market capitalization across all assets
@@ -169,14 +169,14 @@ Provides an overview of the entire cryptocurrency market:
 - Bitcoin dominance percentage
 - Top gainers and losers
 
-#### market.rates
+#### market-rates
 
 Returns USD-based conversion rates for fiat currencies and cryptocurrencies:
 - All fiat currency rates (USD base)
 - Top 10 cryptocurrency rates
 - Optional `slug` parameter (e.g. `euro`, `bitcoin`) for a single rate lookup
 
-#### market.exchanges
+#### market-exchanges
 
 Lists top cryptocurrency exchanges ranked by 24h volume:
 - Exchange name, rank, and 24h volume in USD
@@ -184,7 +184,7 @@ Lists top cryptocurrency exchanges ranked by 24h volume:
 - Optional `exchangeId` parameter (e.g. `binance`) for single exchange details
 - Optional `limit` parameter (1–50, default 10)
 
-#### assets.top
+#### assets-top
 
 Lists top cryptocurrencies ranked by market cap, including:
 - Current price in USD
@@ -192,14 +192,14 @@ Lists top cryptocurrencies ranked by market cap, including:
 - Market cap and rank
 - Configurable result count (1–50, default 10)
 
-#### assets.search
+#### assets-search
 
 Searches for cryptocurrencies by name or symbol with fuzzy matching:
 - Returns matching assets with symbol, name, price, and rank
 - Configurable result count (1–50, default 10)
 - Example: search "bit" returns Bitcoin, Bitcoin Cash, BitTorrent, etc.
 
-#### assets.info
+#### assets-info
 
 Returns detailed metadata for a single cryptocurrency:
 - ID, rank, symbol, and name
@@ -207,14 +207,14 @@ Returns detailed metadata for a single cryptocurrency:
 - Circulating supply and max supply
 - VWAP (24h)
 
-#### assets.compare
+#### assets-compare
 
 Compares 2–5 cryptocurrencies side by side:
 - Price, 24h change, market cap, volume, and rank for each asset
 - Comma-separated symbols (e.g. `BTC,ETH,SOL`)
 - Highlights best performer by 24h change
 
-#### analysis.historical
+#### analysis-historical
 
 Analyzes historical price data with:
 - Customizable time intervals (5min to 1 day)
@@ -223,7 +223,7 @@ Analyzes historical price data with:
 - Volatility metrics
 - High/low price ranges
 
-#### analysis.technical
+#### analysis-technical
 
 Returns the latest technical indicators for any cryptocurrency:
 - SMA (Simple Moving Average) with period
@@ -232,7 +232,7 @@ Returns the latest technical indicators for any cryptocurrency:
 - MACD with signal line, histogram, and Bullish/Bearish label
 - VWAP (Volume Weighted Average Price, 24h)
 
-#### analysis.candlestick
+#### analysis-candlestick
 
 Retrieves OHLCV candlestick data from a specific exchange:
 - Open, high, low, close, and volume for each candle

--- a/src/http.ts
+++ b/src/http.ts
@@ -54,7 +54,7 @@ const serverCard = {
   },
   tools: [
     {
-      name: 'price.get',
+      name: 'price-get',
       description: 'Get current price and 24h stats for a cryptocurrency',
       inputSchema: {
         type: 'object',
@@ -96,7 +96,7 @@ const serverCard = {
       },
     },
     {
-      name: 'market.analysis',
+      name: 'market-analysis',
       description:
         'Get detailed market analysis including top exchanges and volume distribution',
       inputSchema: {
@@ -154,7 +154,7 @@ const serverCard = {
       },
     },
     {
-      name: 'analysis.historical',
+      name: 'analysis-historical',
       description: 'Get historical price analysis with customizable timeframe',
       inputSchema: {
         type: 'object',
@@ -214,7 +214,7 @@ const serverCard = {
       },
     },
     {
-      name: 'assets.top',
+      name: 'assets-top',
       description: 'Get top cryptocurrencies ranked by market cap',
       inputSchema: {
         type: 'object',
@@ -268,7 +268,7 @@ const serverCard = {
       },
     },
     {
-      name: 'analysis.technical',
+      name: 'analysis-technical',
       description:
         'Get the latest technical indicators for a cryptocurrency including SMA, EMA, RSI, MACD, and VWAP',
       inputSchema: {
@@ -345,7 +345,7 @@ const serverCard = {
       },
     },
     {
-      name: 'market.rates',
+      name: 'market-rates',
       description:
         "Get USD-based conversion rates for fiat currencies and cryptocurrencies. Optionally pass a slug (e.g. 'euro', 'us-dollar', 'bitcoin') to look up a single rate.",
       inputSchema: {
@@ -387,7 +387,7 @@ const serverCard = {
       },
     },
     {
-      name: 'market.exchanges',
+      name: 'market-exchanges',
       description:
         "Get top cryptocurrency exchanges ranked by 24h volume. Optionally pass an exchangeId (e.g. 'binance', 'coinbase') to get details for a specific exchange.",
       inputSchema: {
@@ -447,7 +447,7 @@ const serverCard = {
       },
     },
     {
-      name: 'assets.search',
+      name: 'assets-search',
       description:
         'Search for cryptocurrencies by name, symbol, or partial match. Returns multiple matching assets with their ID, name, symbol, rank, and current price.',
       inputSchema: {
@@ -498,7 +498,7 @@ const serverCard = {
       },
     },
     {
-      name: 'market.global',
+      name: 'market-global',
       description:
         'Get a global overview of the cryptocurrency market including total market capitalization, 24-hour trading volume, Bitcoin dominance percentage, and the number of active cryptocurrencies.',
       inputSchema: {
@@ -528,7 +528,7 @@ const serverCard = {
       },
     },
     {
-      name: 'assets.compare',
+      name: 'assets-compare',
       description:
         'Compare 2-5 cryptocurrencies side-by-side including price, 24h change, volume, market cap, and rank. Pass symbols as a comma-separated list (e.g. "BTC,ETH,SOL").',
       inputSchema: {
@@ -585,7 +585,7 @@ const serverCard = {
       },
     },
     {
-      name: 'analysis.candlestick',
+      name: 'analysis-candlestick',
       description:
         'Get OHLCV candlestick data for a cryptocurrency from a specific exchange. Useful for charting and technical analysis.',
       inputSchema: {
@@ -657,7 +657,7 @@ const serverCard = {
       },
     },
     {
-      name: 'price.convert',
+      name: 'price-convert',
       description:
         'Convert a cryptocurrency amount to any fiat currency (e.g. USD, EUR, JPY). Uses real-time exchange rates for accurate conversions.',
       inputSchema: {
@@ -710,7 +710,7 @@ const serverCard = {
       },
     },
     {
-      name: 'assets.info',
+      name: 'assets-info',
       description:
         'Get detailed metadata for a cryptocurrency including ID, rank, supply, max supply, VWAP, market cap, and 24h volume.',
       inputSchema: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export function createServer({
   });
 
   server.registerTool(
-    'price.get',
+    'price-get',
     {
       title: 'Get Crypto Price',
       description:
@@ -118,7 +118,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'market.analysis',
+    'market-analysis',
     {
       title: 'Get Market Analysis',
       description:
@@ -140,7 +140,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'analysis.historical',
+    'analysis-historical',
     {
       title: 'Get Historical Analysis',
       description:
@@ -162,7 +162,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'assets.top',
+    'assets-top',
     {
       title: 'Get Top Assets',
       description:
@@ -184,7 +184,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'analysis.technical',
+    'analysis-technical',
     {
       title: 'Get Technical Analysis',
       description:
@@ -206,7 +206,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'market.rates',
+    'market-rates',
     {
       title: 'Get Currency Rates',
       description:
@@ -228,7 +228,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'market.exchanges',
+    'market-exchanges',
     {
       title: 'Get Exchanges',
       description:
@@ -250,7 +250,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'assets.search',
+    'assets-search',
     {
       title: 'Search Crypto Assets',
       description:
@@ -272,7 +272,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'market.global',
+    'market-global',
     {
       title: 'Get Global Metrics',
       description:
@@ -294,7 +294,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'assets.compare',
+    'assets-compare',
     {
       title: 'Compare Cryptocurrencies',
       description:
@@ -316,7 +316,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'analysis.candlestick',
+    'analysis-candlestick',
     {
       title: 'Get Candlestick Data',
       description:
@@ -338,7 +338,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'price.convert',
+    'price-convert',
     {
       title: 'Get Price Conversion',
       description:
@@ -360,7 +360,7 @@ export function createServer({
   );
 
   server.registerTool(
-    'assets.info',
+    'assets-info',
     {
       title: 'Get Asset Info',
       description:


### PR DESCRIPTION
## Problem

Smithery (and other MCP platforms) reject tool names containing dots. The MCP spec requires names to match `^[a-zA-Z0-9_-]{1,64}$`. SEP-986 (which proposed allowing dots) is still a proposal and not adopted.

Error from Smithery:
```
tools.102.FrontendRemoteMcpToolDefinition.name: String should match pattern '^[a-zA-Z0-9_-]{1,64}$'
```

## Fix

Reverted all 13 tool names from dot-notation to hyphen-based category-prefixed names:

| Old | New |
|-----|-----|
| `price.get` | `price-get` |
| `price.convert` | `price-convert` |
| `market.analysis` | `market-analysis` |
| `market.global` | `market-global` |
| `market.rates` | `market-rates` |
| `market.exchanges` | `market-exchanges` |
| `assets.top` | `assets-top` |
| `assets.search` | `assets-search` |
| `assets.info` | `assets-info` |
| `assets.compare` | `assets-compare` |
| `analysis.historical` | `analysis-historical` |
| `analysis.technical` | `analysis-technical` |
| `analysis.candlestick` | `analysis-candlestick` |

Files updated: `src/index.ts`, `src/http.ts`, `README.md`, `CLAUDE.md`

## Verification

- `pnpm build` ✅
- `pnpm lint` ✅  
- `pnpm test` — 89 tests passed ✅

## Breaking Change

This is a breaking change for any clients currently using dot-notation tool names. The hyphen-based names still maintain the hierarchical tree structure for Smithery AI scoring.