### PR TITLE
fix: add structuredContent to all early return and error paths

### DIFF
--- a/src/tools/asset-info.ts
+++ b/src/tools/asset-info.ts
@@ -38,6 +38,19 @@ export async function handleGetAssetInfo(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          id: '',
+          rank: null,
+          symbol: upperSymbol,
+          name: '',
+          priceUsd: '',
+          changePercent24Hr: null,
+          marketCapUsd: null,
+          volumeUsd24Hr: null,
+          supply: null,
+          maxSupply: null,
+          vwap24Hr: null,
+        },
       };
     }
 
@@ -67,6 +80,19 @@ export async function handleGetAssetInfo(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: {
+          id: '',
+          rank: null,
+          symbol: '',
+          name: '',
+          priceUsd: '',
+          changePercent24Hr: null,
+          marketCapUsd: null,
+          volumeUsd24Hr: null,
+          supply: null,
+          maxSupply: null,
+          vwap24Hr: null,
+        },
       };
     }
     return {
@@ -79,6 +105,19 @@ export async function handleGetAssetInfo(args: unknown) {
               : `Failed to retrieve asset info: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        id: '',
+        rank: null,
+        symbol: '',
+        name: '',
+        priceUsd: '',
+        changePercent24Hr: null,
+        marketCapUsd: null,
+        volumeUsd24Hr: null,
+        supply: null,
+        maxSupply: null,
+        vwap24Hr: null,
+      },
     };
   }
 }

--- a/src/tools/candlestick.ts
+++ b/src/tools/candlestick.ts
@@ -60,6 +60,12 @@ export async function handleGetCandlestickData(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: upperSymbol,
+          exchange,
+          candles: [],
+        },
       };
     }
 
@@ -80,6 +86,12 @@ export async function handleGetCandlestickData(args: unknown) {
         content: [
           { type: 'text', text: 'Failed to retrieve candlestick data' },
         ],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          exchange,
+          candles: [],
+        },
       };
     }
 
@@ -91,6 +103,12 @@ export async function handleGetCandlestickData(args: unknown) {
             text: `No candlestick data available for ${asset.name} (${asset.symbol}) on ${exchange} with quote ${quote.toUpperCase()}`,
           },
         ],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          exchange,
+          candles: [],
+        },
       };
     }
 
@@ -125,6 +143,12 @@ export async function handleGetCandlestickData(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: '',
+          exchange: '',
+          candles: [],
+        },
       };
     }
     return {
@@ -137,6 +161,12 @@ export async function handleGetCandlestickData(args: unknown) {
               : `Failed to retrieve candlestick data: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        name: '',
+        symbol: '',
+        exchange: '',
+        candles: [],
+      },
     };
   }
 }

--- a/src/tools/compare.ts
+++ b/src/tools/compare.ts
@@ -43,6 +43,7 @@ export async function handleCompareCrypto(args: unknown) {
             text: 'Please provide 2-5 cryptocurrency symbols to compare (e.g. "BTC,ETH,SOL")',
           },
         ],
+        structuredContent: { assets: [], notFound: symbolList },
       };
     }
 
@@ -66,6 +67,7 @@ export async function handleCompareCrypto(args: unknown) {
             text: `Could not find any of the specified cryptocurrencies: ${symbolList.join(', ')}`,
           },
         ],
+        structuredContent: { assets: [], notFound },
       };
     }
 
@@ -99,6 +101,7 @@ export async function handleCompareCrypto(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: { assets: [], notFound: [] },
       };
     }
     return {
@@ -111,6 +114,7 @@ export async function handleCompareCrypto(args: unknown) {
               : `Failed to compare cryptocurrencies: ${String(error)}`,
         },
       ],
+      structuredContent: { assets: [], notFound: [] },
     };
   }
 }

--- a/src/tools/exchanges.ts
+++ b/src/tools/exchanges.ts
@@ -50,6 +50,7 @@ export async function handleGetExchanges(args: unknown) {
               text: `Could not find exchange "${exchangeId}". Try an ID like 'binance', 'coinbase', or 'kraken'.`,
             },
           ],
+          structuredContent: { exchanges: [] },
         };
       }
 
@@ -76,6 +77,7 @@ export async function handleGetExchanges(args: unknown) {
     if (!exchanges) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve exchanges' }],
+        structuredContent: { exchanges: [] },
       };
     }
 
@@ -106,6 +108,7 @@ export async function handleGetExchanges(args: unknown) {
               : `Failed to retrieve exchanges: ${String(error)}`,
         },
       ],
+      structuredContent: { exchanges: [] },
     };
   }
 }

--- a/src/tools/global-metrics.ts
+++ b/src/tools/global-metrics.ts
@@ -22,12 +22,24 @@ export async function handleGetGlobalMetrics(args: unknown) {
         content: [
           { type: 'text', text: 'Failed to retrieve global market data' },
         ],
+        structuredContent: {
+          totalMarketCap: 0,
+          totalVolume: 0,
+          btcDominance: '',
+          activeCryptocurrencies: 0,
+        },
       };
     }
 
     if (!assetsData.data.length) {
       return {
         content: [{ type: 'text', text: 'No market data available' }],
+        structuredContent: {
+          totalMarketCap: 0,
+          totalVolume: 0,
+          btcDominance: '',
+          activeCryptocurrencies: 0,
+        },
       };
     }
 
@@ -67,6 +79,12 @@ export async function handleGetGlobalMetrics(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: {
+          totalMarketCap: 0,
+          totalVolume: 0,
+          btcDominance: '',
+          activeCryptocurrencies: 0,
+        },
       };
     }
     return {
@@ -79,6 +97,12 @@ export async function handleGetGlobalMetrics(args: unknown) {
               : `Failed to retrieve global market data: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        totalMarketCap: 0,
+        totalVolume: 0,
+        btcDominance: '',
+        activeCryptocurrencies: 0,
+      },
     };
   }
 }

--- a/src/tools/historical.ts
+++ b/src/tools/historical.ts
@@ -48,6 +48,17 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: upperSymbol,
+          periodHigh: 0,
+          periodLow: 0,
+          priceChangePercent: '',
+          currentPrice: 0,
+          startingPrice: 0,
+          priceRange: 0,
+          rangePercentage: '',
+        },
       };
     }
 
@@ -61,6 +72,17 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
     if (!historyData) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve historical data' }],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          periodHigh: 0,
+          periodLow: 0,
+          priceChangePercent: '',
+          currentPrice: 0,
+          startingPrice: 0,
+          priceRange: 0,
+          rangePercentage: '',
+        },
       };
     }
 
@@ -72,6 +94,17 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
             text: 'No historical data available for the selected time period',
           },
         ],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          periodHigh: 0,
+          periodLow: 0,
+          priceChangePercent: '',
+          currentPrice: 0,
+          startingPrice: 0,
+          priceRange: 0,
+          rangePercentage: '',
+        },
       };
     }
 
@@ -121,6 +154,17 @@ export async function handleGetHistoricalAnalysis(args: unknown) {
               : `Failed to retrieve historical data: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        name: '',
+        symbol: '',
+        periodHigh: 0,
+        periodLow: 0,
+        priceChangePercent: '',
+        currentPrice: 0,
+        startingPrice: 0,
+        priceRange: 0,
+        rangePercentage: '',
+      },
     };
   }
 }

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -40,6 +40,14 @@ export async function handleGetMarketAnalysis(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: upperSymbol,
+          priceUsd: '',
+          volumeUsd24Hr: null,
+          vwap24Hr: null,
+          topMarkets: [],
+        },
       };
     }
 
@@ -48,6 +56,14 @@ export async function handleGetMarketAnalysis(args: unknown) {
     if (!marketsData) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve market data' }],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          priceUsd: asset.priceUsd,
+          volumeUsd24Hr: asset.volumeUsd24Hr,
+          vwap24Hr: asset.vwap24Hr,
+          topMarkets: [],
+        },
       };
     }
 
@@ -92,6 +108,14 @@ export async function handleGetMarketAnalysis(args: unknown) {
               : `Failed to retrieve data: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        name: '',
+        symbol: '',
+        priceUsd: '',
+        volumeUsd24Hr: null,
+        vwap24Hr: null,
+        topMarkets: [],
+      },
     };
   }
 }

--- a/src/tools/price-conversion.ts
+++ b/src/tools/price-conversion.ts
@@ -43,6 +43,13 @@ export async function handleGetPriceConversion(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          fromSymbol: upperSymbol,
+          amount,
+          toCurrency: upperCurrency,
+          conversionRate: 0,
+          convertedAmount: 0,
+        },
       };
     }
 
@@ -51,6 +58,13 @@ export async function handleGetPriceConversion(args: unknown) {
     if (!rates) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve exchange rates' }],
+        structuredContent: {
+          fromSymbol: upperSymbol,
+          amount,
+          toCurrency: upperCurrency,
+          conversionRate: 0,
+          convertedAmount: 0,
+        },
       };
     }
 
@@ -64,6 +78,13 @@ export async function handleGetPriceConversion(args: unknown) {
             text: `Could not find exchange rate for currency "${currency}". Available currencies include: usd, eur, gbp, jpy, etc.`,
           },
         ],
+        structuredContent: {
+          fromSymbol: upperSymbol,
+          amount,
+          toCurrency: upperCurrency,
+          conversionRate: 0,
+          convertedAmount: 0,
+        },
       };
     }
 
@@ -101,6 +122,13 @@ export async function handleGetPriceConversion(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: {
+          fromSymbol: '',
+          amount: 0,
+          toCurrency: '',
+          conversionRate: 0,
+          convertedAmount: 0,
+        },
       };
     }
     return {
@@ -113,6 +141,13 @@ export async function handleGetPriceConversion(args: unknown) {
               : `Failed to convert price: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        fromSymbol: '',
+        amount: 0,
+        toCurrency: '',
+        conversionRate: 0,
+        convertedAmount: 0,
+      },
     };
   }
 }

--- a/src/tools/price.ts
+++ b/src/tools/price.ts
@@ -34,6 +34,15 @@ export async function handleGetPrice(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: upperSymbol,
+          priceUsd: '',
+          changePercent24Hr: null,
+          volumeUsd24Hr: null,
+          marketCapUsd: null,
+          rank: null,
+        },
       };
     }
 
@@ -60,6 +69,15 @@ export async function handleGetPrice(args: unknown) {
               : `Failed to retrieve cryptocurrency data: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        name: '',
+        symbol: '',
+        priceUsd: '',
+        changePercent24Hr: null,
+        volumeUsd24Hr: null,
+        marketCapUsd: null,
+        rank: null,
+      },
     };
   }
 }

--- a/src/tools/rates.ts
+++ b/src/tools/rates.ts
@@ -38,6 +38,7 @@ export async function handleGetRates(args: unknown) {
               text: `Could not find rate for slug "${slug}". Try a slug like 'us-dollar', 'euro', or 'bitcoin'.`,
             },
           ],
+          structuredContent: { rates: [] },
         };
       }
 
@@ -62,6 +63,7 @@ export async function handleGetRates(args: unknown) {
     if (!rates) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve currency rates' }],
+        structuredContent: { rates: [] },
       };
     }
 
@@ -88,6 +90,7 @@ export async function handleGetRates(args: unknown) {
               : `Failed to retrieve rates: ${String(error)}`,
         },
       ],
+      structuredContent: { rates: [] },
     };
   }
 }

--- a/src/tools/search-assets.ts
+++ b/src/tools/search-assets.ts
@@ -39,6 +39,7 @@ export async function handleSearchAssets(args: unknown) {
     if (!results) {
       return {
         content: [{ type: 'text', text: 'Failed to search for assets' }],
+        structuredContent: { results: [] },
       };
     }
 
@@ -50,6 +51,7 @@ export async function handleSearchAssets(args: unknown) {
             text: `No cryptocurrencies found matching "${query}"`,
           },
         ],
+        structuredContent: { results: [] },
       };
     }
 
@@ -75,6 +77,7 @@ export async function handleSearchAssets(args: unknown) {
             text: `Invalid input: ${error.issues.map((e) => e.message).join(', ')}`,
           },
         ],
+        structuredContent: { results: [] },
       };
     }
     return {
@@ -87,6 +90,7 @@ export async function handleSearchAssets(args: unknown) {
               : `Failed to search for assets: ${String(error)}`,
         },
       ],
+      structuredContent: { results: [] },
     };
   }
 }

--- a/src/tools/technical-analysis.ts
+++ b/src/tools/technical-analysis.ts
@@ -44,6 +44,16 @@ export async function handleGetTechnicalAnalysis(args: unknown) {
             text: `Could not find cryptocurrency with symbol ${upperSymbol}`,
           },
         ],
+        structuredContent: {
+          name: '',
+          symbol: upperSymbol,
+          currentPrice: '',
+          sma: null,
+          ema: null,
+          rsi: null,
+          macd: null,
+          vwap: null,
+        },
       };
     }
 
@@ -57,6 +67,16 @@ export async function handleGetTechnicalAnalysis(args: unknown) {
             text: `Failed to retrieve technical analysis for ${asset.name} (${asset.symbol})`,
           },
         ],
+        structuredContent: {
+          name: asset.name,
+          symbol: asset.symbol,
+          currentPrice: asset.priceUsd,
+          sma: null,
+          ema: null,
+          rsi: null,
+          macd: null,
+          vwap: null,
+        },
       };
     }
 
@@ -115,6 +135,16 @@ export async function handleGetTechnicalAnalysis(args: unknown) {
               : `Failed to retrieve technical analysis: ${String(error)}`,
         },
       ],
+      structuredContent: {
+        name: '',
+        symbol: '',
+        currentPrice: '',
+        sma: null,
+        ema: null,
+        rsi: null,
+        macd: null,
+        vwap: null,
+      },
     };
   }
 }

--- a/src/tools/top-assets.ts
+++ b/src/tools/top-assets.ts
@@ -34,6 +34,7 @@ export async function handleGetTopAssets(args: unknown) {
     if (!assetsData) {
       return {
         content: [{ type: 'text', text: 'Failed to retrieve assets data' }],
+        structuredContent: { assets: [] },
       };
     }
 
@@ -42,6 +43,7 @@ export async function handleGetTopAssets(args: unknown) {
     if (!topAssets.length) {
       return {
         content: [{ type: 'text', text: 'No assets data available' }],
+        structuredContent: { assets: [] },
       };
     }
 
@@ -70,6 +72,7 @@ export async function handleGetTopAssets(args: unknown) {
               : `Failed to retrieve assets data: ${String(error)}`,
         },
       ],
+      structuredContent: { assets: [] },
     };
   }
 }


### PR DESCRIPTION
## Problem

When `outputSchema` is registered on a tool, the MCP SDK requires `structuredContent` on **every** response — including error paths, not-found cases, and validation errors. Missing it caused:

```
MCP error -32602: Output validation error: Tool assets-compare has an output schema but no structured content was provided
```

## Fix

Added schema-compliant default `structuredContent` to all early return and error paths across all 13 tool handlers:

| File | Paths fixed |
|------|-------------|
| `price.ts` | not-found, catch |
| `market.ts` | not-found, failed, catch |
| `historical.ts` | not-found, failed, empty, catch |
| `top-assets.ts` | failed, empty, catch |
| `technical-analysis.ts` | not-found, failed, catch |
| `rates.ts` | not-found |
| `exchanges.ts` | not-found |
| `search-assets.ts` | failed, empty, catch |
| `global-metrics.ts` | failed, empty, catch |
| `candlestick.ts` | not-found, failed, empty, catch |
| `price-conversion.ts` | not-found, failed, catch |
| `asset-info.ts` | not-found, catch |
| `compare.ts` | invalid-count, not-found, catch |

## Verification

- `pnpm build` ✅
- `pnpm lint` ✅
- `pnpm test` — 89 tests passed ✅