### PR TITLE
fix: normalize quote currency IDs for candlestick API and improve error messages

### DIFF
--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -388,6 +388,22 @@ export async function getExchange(
   }
 }
 
+const QUOTE_ID_MAP: Record<string, string> = {
+  usd: 'us-dollar',
+  eur: 'euro',
+  gbp: 'british-pound',
+  jpy: 'japanese-yen',
+  usdt: 'tether',
+  usdc: 'usd-coin',
+  btc: 'bitcoin',
+  eth: 'ethereum',
+};
+
+function normalizeQuoteId(quote: string): string {
+  const lower = quote.toLowerCase();
+  return QUOTE_ID_MAP[lower] ?? lower;
+}
+
 export async function getCandles(
   exchange: string,
   baseId: string,
@@ -396,14 +412,20 @@ export async function getCandles(
   start: number,
   end: number
 ): Promise<CandlesResponse | null> {
+  const normalizedQuoteId = normalizeQuoteId(quoteId);
   try {
     return await makeCoinCapRequest<CandlesResponse>(
-      `/candles?exchange=${encodeURIComponent(exchange)}&baseId=${encodeURIComponent(baseId)}&quoteId=${encodeURIComponent(quoteId)}&interval=${interval}&start=${start}&end=${end}`,
+      `/candles?exchange=${encodeURIComponent(exchange)}&baseId=${encodeURIComponent(baseId)}&quoteId=${encodeURIComponent(normalizedQuoteId)}&interval=${interval}&start=${start}&end=${end}`,
       CandlesResponseSchema
     );
   } catch (error) {
     if (error instanceof MissingApiKeyError) throw error;
-    console.error('Failed to get candles:', error);
+    const detail =
+      error instanceof Error ? error.message : String(error);
+    console.error(
+      `Failed to get candles for ${exchange} ${baseId}/${normalizedQuoteId}:`,
+      detail
+    );
     return null;
   }
 }

--- a/src/tools/__tests__/candlestick.test.ts
+++ b/src/tools/__tests__/candlestick.test.ts
@@ -79,7 +79,8 @@ describe('handleGetCandlestickData', () => {
     mockGetCandles.mockResolvedValueOnce(null);
 
     const result = await handleGetCandlestickData({ symbol: 'BTC' });
-    expect(result.content[0].text).toBe('Failed to retrieve candlestick data');
+    expect(result.content[0].text).toContain('Failed to retrieve candlestick data');
+    expect(result.content[0].text).toContain('Try a different quote currency');
   });
 
   it('should return no-data message when candles array is empty', async () => {

--- a/src/tools/candlestick.ts
+++ b/src/tools/candlestick.ts
@@ -14,7 +14,9 @@ export const GetCandlestickDataSchema = z.object({
   quote: z
     .string()
     .default('usd')
-    .describe('Quote currency ID (e.g. "usd", "usdt", "btc")'),
+    .describe(
+      'Quote currency code (e.g. "usd", "usdt", "btc", "eur"). Common mappings: usd→us-dollar, usdt→tether, usdc→usd-coin. Not all exchanges support all quote currencies — e.g. Binance uses "usdt" not "usd".'
+    ),
   interval: z
     .enum(['m5', 'm15', 'm30', 'h1', 'h2', 'h6', 'h12', 'd1'])
     .default('h1')
@@ -84,7 +86,10 @@ export async function handleGetCandlestickData(args: unknown) {
     if (!candlesData) {
       return {
         content: [
-          { type: 'text', text: 'Failed to retrieve candlestick data' },
+          {
+            type: 'text',
+            text: `Failed to retrieve candlestick data for ${asset.name} (${asset.symbol}) on ${exchange} with quote "${quote}". This usually means the exchange does not support this trading pair. Try a different quote currency (e.g. "usdt" for Binance) or a different exchange (e.g. "kraken" supports USD pairs).`,
+          },
         ],
         structuredContent: {
           name: asset.name,


### PR DESCRIPTION
## Problem

Calling `analysis-candlestick` with `exchange: "binance"` and `quote: "usd"` returned a generic "Failed to retrieve candlestick data" error.

**Root cause**: The CoinCap candles endpoint expects valid CoinCap asset/rate IDs as `quoteId` (e.g., `us-dollar`, `tether`), not currency codes like `usd`, `usdt`. Binance doesn't support BTC/USD — it uses BTC/USDT (Tether).

## Fix

1. **Quote ID normalization** in `getCandles()` — maps common currency codes to their CoinCap IDs:
   - `usd` → `us-dollar`
   - `usdt` → `tether`
   - `usdc` → `usd-coin`
   - `eur` → `euro`, `gbp` → `british-pound`, `jpy` → `japanese-yen`
   - `btc` → `bitcoin`, `eth` → `ethereum`

2. **Improved error message** — now includes the exchange, asset, quote currency, and actionable guidance (e.g., "try usdt for Binance")

3. **Updated tool description** — mentions common mappings and that not all exchanges support all quote currencies

## Verification

- `pnpm build` ✅
- `pnpm lint` ✅
- `pnpm test` — 89 tests passed ✅