### PR TITLE
fix: migrate candlestick tool to v3 /ta/{slug}/candlesticks endpoint

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -587,24 +587,13 @@ const serverCard = {
     {
       name: 'analysis-candlestick',
       description:
-        'Get OHLCV candlestick data for a cryptocurrency from a specific exchange. Useful for charting and technical analysis.',
+        'Get OHLCV candlestick data for a cryptocurrency. Useful for charting and technical analysis.',
       inputSchema: {
         type: 'object',
         properties: {
           symbol: {
             type: 'string',
             description: 'Cryptocurrency symbol or name (e.g. BTC or Bitcoin)',
-          },
-          exchange: {
-            type: 'string',
-            default: 'poloniex',
-            description:
-              'Exchange ID (e.g. "poloniex", "bittrex", "kraken", "binance")',
-          },
-          quote: {
-            type: 'string',
-            default: 'usd',
-            description: 'Quote currency ID (e.g. "usd", "usdt", "btc")',
           },
           interval: {
             type: 'string',
@@ -629,7 +618,6 @@ const serverCard = {
         properties: {
           name: { type: 'string' },
           symbol: { type: 'string' },
-          exchange: { type: 'string' },
           candles: {
             type: 'array',
             items: {
@@ -646,7 +634,7 @@ const serverCard = {
             },
           },
         },
-        required: ['name', 'symbol', 'exchange', 'candles'],
+        required: ['name', 'symbol', 'candles'],
       },
       annotations: {
         title: 'Get Candlestick Data',

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,7 @@ export function createServer({
     {
       title: 'Get Candlestick Data',
       description:
-        'Get OHLCV candlestick data for a cryptocurrency from a specific exchange. Useful for charting and technical analysis.',
+        'Get OHLCV candlestick data for a cryptocurrency. Useful for charting and technical analysis.',
       inputSchema: GetCandlestickDataSchema.shape,
       outputSchema: CandlestickOutputSchema.shape,
       annotations: {

--- a/src/services/coincap.ts
+++ b/src/services/coincap.ts
@@ -388,34 +388,15 @@ export async function getExchange(
   }
 }
 
-const QUOTE_ID_MAP: Record<string, string> = {
-  usd: 'us-dollar',
-  eur: 'euro',
-  gbp: 'british-pound',
-  jpy: 'japanese-yen',
-  usdt: 'tether',
-  usdc: 'usd-coin',
-  btc: 'bitcoin',
-  eth: 'ethereum',
-};
-
-function normalizeQuoteId(quote: string): string {
-  const lower = quote.toLowerCase();
-  return QUOTE_ID_MAP[lower] ?? lower;
-}
-
 export async function getCandles(
-  exchange: string,
-  baseId: string,
-  quoteId: string,
+  assetId: string,
   interval: string,
   start: number,
   end: number
 ): Promise<CandlesResponse | null> {
-  const normalizedQuoteId = normalizeQuoteId(quoteId);
   try {
     return await makeCoinCapRequest<CandlesResponse>(
-      `/candles?exchange=${encodeURIComponent(exchange)}&baseId=${encodeURIComponent(baseId)}&quoteId=${encodeURIComponent(normalizedQuoteId)}&interval=${interval}&start=${start}&end=${end}`,
+      `/ta/${encodeURIComponent(assetId)}/candlesticks?interval=${interval}&start=${start}&end=${end}`,
       CandlesResponseSchema
     );
   } catch (error) {
@@ -423,7 +404,7 @@ export async function getCandles(
     const detail =
       error instanceof Error ? error.message : String(error);
     console.error(
-      `Failed to get candles for ${exchange} ${baseId}/${normalizedQuoteId}:`,
+      `Failed to get candlesticks for ${assetId}:`,
       detail
     );
     return null;

--- a/src/services/formatters.ts
+++ b/src/services/formatters.ts
@@ -330,11 +330,10 @@ export function formatComparison(assets: CryptoAsset[]): string {
 
 export function formatCandlestickData(
   asset: CryptoAsset,
-  candles: Candle[],
-  exchange: string
+  candles: Candle[]
 ): string {
   if (candles.length === 0) {
-    return `No candlestick data available for ${asset.name} (${asset.symbol}) on ${exchange}.`;
+    return `No candlestick data available for ${asset.name} (${asset.symbol}).`;
   }
 
   const lines = candles.map((c) => {
@@ -348,7 +347,7 @@ export function formatCandlestickData(
   });
 
   return [
-    `Candlestick Data for ${asset.name} (${asset.symbol}) — Exchange: ${exchange}`,
+    `Candlestick Data for ${asset.name} (${asset.symbol})`,
     '',
     ...lines,
   ].join('\n');

--- a/src/tools/__tests__/candlestick.test.ts
+++ b/src/tools/__tests__/candlestick.test.ts
@@ -64,7 +64,6 @@ describe('handleGetCandlestickData', () => {
     );
     expect(result.content[0].text).toContain('O: $49000.00');
     expect(result.content[0].text).toContain('C: $50800.00');
-    expect(result.content[0].text).toContain('Exchange: poloniex');
   });
 
   it('should return not-found message for unknown symbol', async () => {
@@ -80,7 +79,6 @@ describe('handleGetCandlestickData', () => {
 
     const result = await handleGetCandlestickData({ symbol: 'BTC' });
     expect(result.content[0].text).toContain('Failed to retrieve candlestick data');
-    expect(result.content[0].text).toContain('Try a different quote currency');
   });
 
   it('should return no-data message when candles array is empty', async () => {

--- a/src/tools/candlestick.ts
+++ b/src/tools/candlestick.ts
@@ -7,16 +7,6 @@ export const GetCandlestickDataSchema = z.object({
     .string()
     .min(1)
     .describe('Cryptocurrency symbol or name (e.g. BTC or Bitcoin)'),
-  exchange: z
-    .string()
-    .default('poloniex')
-    .describe('Exchange ID (e.g. "poloniex", "bittrex", "kraken", "binance")'),
-  quote: z
-    .string()
-    .default('usd')
-    .describe(
-      'Quote currency code (e.g. "usd", "usdt", "btc", "eur"). Common mappings: usd→us-dollar, usdt→tether, usdc→usd-coin. Not all exchanges support all quote currencies — e.g. Binance uses "usdt" not "usd".'
-    ),
   interval: z
     .enum(['m5', 'm15', 'm30', 'h1', 'h2', 'h6', 'h12', 'd1'])
     .default('h1')
@@ -34,7 +24,6 @@ export const GetCandlestickDataSchema = z.object({
 export const CandlestickOutputSchema = z.object({
   name: z.string(),
   symbol: z.string(),
-  exchange: z.string(),
   candles: z.array(
     z.object({
       open: z.string(),
@@ -49,7 +38,7 @@ export const CandlestickOutputSchema = z.object({
 
 export async function handleGetCandlestickData(args: unknown) {
   try {
-    const { symbol, exchange, quote, interval, days } =
+    const { symbol, interval, days } =
       GetCandlestickDataSchema.parse(args);
     const upperSymbol = symbol.toUpperCase();
     const asset = await searchAsset(upperSymbol);
@@ -65,7 +54,6 @@ export async function handleGetCandlestickData(args: unknown) {
         structuredContent: {
           name: '',
           symbol: upperSymbol,
-          exchange,
           candles: [],
         },
       };
@@ -75,9 +63,7 @@ export async function handleGetCandlestickData(args: unknown) {
     const end = now - (now % 60000);
     const start = end - days * 24 * 60 * 60 * 1000;
     const candlesData = await getCandles(
-      exchange,
       asset.id,
-      quote,
       interval,
       start,
       end
@@ -88,13 +74,12 @@ export async function handleGetCandlestickData(args: unknown) {
         content: [
           {
             type: 'text',
-            text: `Failed to retrieve candlestick data for ${asset.name} (${asset.symbol}) on ${exchange} with quote "${quote}". This usually means the exchange does not support this trading pair. Try a different quote currency (e.g. "usdt" for Binance) or a different exchange (e.g. "kraken" supports USD pairs).`,
+            text: `Failed to retrieve candlestick data for ${asset.name} (${asset.symbol}).`,
           },
         ],
         structuredContent: {
           name: asset.name,
           symbol: asset.symbol,
-          exchange,
           candles: [],
         },
       };
@@ -105,13 +90,12 @@ export async function handleGetCandlestickData(args: unknown) {
         content: [
           {
             type: 'text',
-            text: `No candlestick data available for ${asset.name} (${asset.symbol}) on ${exchange} with quote ${quote.toUpperCase()}`,
+            text: `No candlestick data available for ${asset.name} (${asset.symbol})`,
           },
         ],
         structuredContent: {
           name: asset.name,
           symbol: asset.symbol,
-          exchange,
           candles: [],
         },
       };
@@ -121,13 +105,12 @@ export async function handleGetCandlestickData(args: unknown) {
       content: [
         {
           type: 'text',
-          text: formatCandlestickData(asset, candlesData.data, exchange),
+          text: formatCandlestickData(asset, candlesData.data),
         },
       ],
       structuredContent: {
         name: asset.name,
         symbol: asset.symbol,
-        exchange,
         candles: candlesData.data.map((c) => ({
           open: c.open,
           high: c.high,
@@ -151,7 +134,6 @@ export async function handleGetCandlestickData(args: unknown) {
         structuredContent: {
           name: '',
           symbol: '',
-          exchange: '',
           candles: [],
         },
       };
@@ -169,7 +151,6 @@ export async function handleGetCandlestickData(args: unknown) {
       structuredContent: {
         name: '',
         symbol: '',
-        exchange: '',
         candles: [],
       },
     };


### PR DESCRIPTION
## Problem

The candlestick tool was calling the old v2 `/candles` endpoint with `exchange`, `baseId`, and `quoteId` parameters. This endpoint **does not exist** in the CoinCap v3 API, so every request failed with "Failed to retrieve candlestick data".

## Root Cause

The CoinCap v3 OpenAPI spec (https://rest.coincap.io/api-docs.json) confirms there is no `/candles` endpoint. Instead, v3 provides `/ta/{slug}/candlesticks` which takes only:
- `slug` (asset ID, e.g. `bitcoin`)
- `interval` (e.g. `d1`)
- `start` / `end` (Unix ms timestamps)

No exchange or quote currency parameters — the v3 API provides asset-level candlesticks rather than per-exchange pair data.

## Fix

- **`coincap.ts`**: Rewrote `getCandles()` to call `/ta/{assetId}/candlesticks?interval=...&start=...&end=...`
- **`candlestick.ts`**: Removed `exchange` and `quote` input parameters, removed `exchange` from output schema
- **`formatters.ts`**: Updated `formatCandlestickData()` to not include exchange in output
- **`index.ts`** / **`http.ts`**: Updated tool descriptions and schemas to match
- **Tests**: Updated to match new API shape (removed exchange/quote assertions)

## Verification

- `pnpm build` ✅
- `pnpm lint` ✅
- `pnpm test` — 89 tests passed ✅